### PR TITLE
Adding target to page links

### DIFF
--- a/archetypes/link.md
+++ b/archetypes/link.md
@@ -9,4 +9,5 @@ tags: []
 
 # Set your external url
 link: "https://github.com/Lednerb/gohugo-theme-bilberry"
+target: "" #_blank|_self|_parent|_top|framename
 ---

--- a/archetypes/page.md
+++ b/archetypes/page.md
@@ -5,4 +5,5 @@ draft: true
 
 # set the link if you want to redirect the user.
 link: ""
+target: "" # _blank|_self|_parent|_top|framename
 ---

--- a/layouts/partials/topnav.html
+++ b/layouts/partials/topnav.html
@@ -7,7 +7,7 @@
         <ul class="topnav">
             {{ range where (where .Site.Pages ".Type" "page") ".IsPage" true }}
                 {{ if and (isset .Params "link") (ne .Params.link "") }}
-                    <li><a href="{{ .Params.link | relURL }}">{{ .Title }}</a></li>
+                    <li><a href="{{ .Params.link | relURL }}" target="{{ .Params.target }}">{{ .Title }}</a></li>
                 {{ else }}
                     <li><a href="{{ .URL }}">{{ .Title }}</a></li>
                 {{ end }}


### PR DESCRIPTION
Added this so you can specify "target:" in the page's front matter, (i.e. target: "_blank")