### PR TITLE
Fix broken links to the theme's repo

### DIFF
--- a/archetypes/link.md
+++ b/archetypes/link.md
@@ -8,5 +8,5 @@ categories: []
 tags: []
 
 # Set your external url
-link: "https://github.com/Lednerb/gohugo-theme-bilberry"
+link: "https://github.com/Lednerb/bilberry-hugo-theme"
 ---

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -65,7 +65,7 @@
             <a href="https://github.com/Lednerb" target="_blank">&copy; 2017 by Lednerb </a>
         </div>
         <div class="author">
-            <a href="https://github.com/Lednerb/gohugo-theme-bilberry" target="_blank">Bilberry Hugo Theme</a>
+            <a href="https://github.com/Lednerb/bilberry-hugo-theme" target="_blank">Bilberry Hugo Theme</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
I suppose the repo was renamed some time ago, and the old links were not updated.