### PR TITLE
Set footer credits and copyright via parameters

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -54,6 +54,14 @@ disqusShortname = "bilberry-hugo-theme"
     # always display the top navigation (with pages and search) on non-mobile screens
     permanentTopNav = false
 
+    # credits line configuration
+    copyrightBy = "by Lednerb"
+    copyrightUseCurrentYear = false  # set to true to always display the current year in the copyright
+    copyrightYearOverride = "2017"
+    copyrightUrl = "https://github.com/Lednerb"
+    creditsText = "Bilberry Hugo Theme"
+    creditsUrl = "https://github.com/Lednerb/bilberry-hugo-theme"
+
   # social media profile urls for the footer links
   facebook   = ""
   twitter    = "https://twitter.com/TheRealLednerb"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -62,10 +62,18 @@
 <div class="credits">
     <div class="container">
         <div class="copyright">
-            <a href="https://github.com/Lednerb" target="_blank">&copy; 2017 by Lednerb </a>
+            <a href="{{ .Site.Params.copyrightUrl }}" target="_blank">
+                &copy;
+                {{ if .Site.Params.copyrightUseCurrentYear }}
+                    {{ now.Year }}
+                {{ else }}
+                    {{ .Site.Params.copyrightYearOverride }}
+                {{ end }}
+                {{ .Site.Params.copyrightBy }}
+            </a>
         </div>
         <div class="author">
-            <a href="https://github.com/Lednerb/bilberry-hugo-theme" target="_blank">Bilberry Hugo Theme</a>
+            <a href="{{ .Site.Params.creditsUrl }}" target="_blank">{{ .Site.Params.creditsText }}</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Introduces new configurable parameters to config.toml to allow customization of the credits and copyright text and links present in the footer. Closes #58 

| parameter 	| default value 	| note 	|
|-------------------------	|----------------------------------------------------	|-----------------------------------------------------------------	|
| copyrightBy 	| `"by Lednerb"` 	|  	|
| copyrightUseCurrentYear 	| `false` 	| set to true to always display the current year in the copyright 	|
| copyrightYearOverride 	| `"2017"` 	|  	|
| copyrightUrl 	| `"https://github.com/Lednerb"` 	|  	|
| creditsText 	| `"Bilberry Hugo Theme"` 	|  	|
| creditsUrl 	| `"https://github.com/Lednerb/bilberry-hugo-theme"` 	|  	|