### PR TITLE
Add Xing support to social media links in footer

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -64,6 +64,7 @@ disqusShortname = "bilberry-hugo-theme"
   youtube    = ""
   vimeo      = ""
   github     = "https://github.com/Lednerb"
+  xing       = ""
 
 # don't change anything here
 [taxonomies]

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -37,6 +37,9 @@
             {{ with .Site.Params.googleplus }}
                 <a href="{{ . }}" target="_blank"><i class="fa fa-google-plus-official"></i></a>
             {{ end }}
+            {{ with .Site.Params.xing }}
+                <a href="{{ . }}" target="_blank"><i class="fa fa-xing"></i></a>
+            {{ end }}
             {{ with .Site.Params.pinterest }}
                 <a href="{{ . }}" target="_blank"><i class="fa fa-pinterest"></i></a>
             {{ end }}


### PR DESCRIPTION
This small PR adds Xing support for the social media links in the footer. Xing is a business networking platform used in job-related context, see https://www.xing.com for further information.