### PR TITLE
Add parameter `restrictToTeaser` to allow plain posts

### DIFF
--- a/layouts/partials/content-type/article.html
+++ b/layouts/partials/content-type/article.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-pencil"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-pencil"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="default article">
     {{ partial "featured-image" . }}

--- a/layouts/partials/content-type/audio.html
+++ b/layouts/partials/content-type/audio.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-music"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-music"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="audio">
     {{ partial "featured-image" . }}

--- a/layouts/partials/content-type/code.html
+++ b/layouts/partials/content-type/code.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-code"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-code"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="default article">
     {{ partial "featured-image" . }}

--- a/layouts/partials/content-type/gallery.html
+++ b/layouts/partials/content-type/gallery.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-camera"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-camera"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="gallery">
     {{ if and (isset .Params "gallery") (ne .Params.gallery "") }}

--- a/layouts/partials/content-type/link.html
+++ b/layouts/partials/content-type/link.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .Params.link }}" target="_blank">
-    <i class="fa fa-fw fa-link"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .Params.link }}" target="_blank">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-link"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="link">
     {{ with .Params.featuredImage }}

--- a/layouts/partials/content-type/page.html
+++ b/layouts/partials/content-type/page.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-file"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-file"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="default article">
     {{ partial "featured-image" . }}

--- a/layouts/partials/content-type/picture.html
+++ b/layouts/partials/content-type/picture.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-camera"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+  <span class="bubble"><i class="fa fa-fw fa-camera"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="picture">
     {{ partial "featured-image" . }}

--- a/layouts/partials/content-type/quote.html
+++ b/layouts/partials/content-type/quote.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-quote-right"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-quote-right"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="quote">
     {{ with .Params.featuredImage }}

--- a/layouts/partials/content-type/video.html
+++ b/layouts/partials/content-type/video.html
@@ -1,6 +1,10 @@
-<a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-video-camera"></i>
-</a>
+{{ if not .Params.restrictToTeaser }}
+    <a href="{{ .URL }}">
+{{ end }}
+    <span class="bubble"><i class="fa fa-fw fa-video-camera"></i></span>
+{{ if not .Params.restrictToTeaser }}
+    </a>
+{{ end }}
 
 <article class="video">
     {{ partial "featured-image" . }}

--- a/layouts/partials/default-content.html
+++ b/layouts/partials/default-content.html
@@ -1,5 +1,7 @@
 <div class="content">
-    <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
+    {{ if not .Params.restrictToTeaser }}
+        <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
+    {{ end }}
     <div class="meta">
         <span class="date moment">{{ .PublishDate.Format "2006-01-02" }}</span>
 
@@ -16,7 +18,7 @@
         {{ end }}
     </div>
 
-    {{ if or (.Scratch.Get "singlePage") (.Params.noSummary) }}
+    {{ if or (.Scratch.Get "singlePage") (.Params.noSummary) (.Params.restrictToTeaser) }}
         {{ .Content }}
     {{ else }}
         {{ .Summary }}

--- a/layouts/partials/featured-image.html
+++ b/layouts/partials/featured-image.html
@@ -1,7 +1,11 @@
 {{ if and (isset .Params "featuredimage") (ne .Params.featuredImage "") }}
     <div class="featured-image">
-        <a href="{{ .URL }}">
+        {{ if not .Params.restrictToTeaser }}
+            <a href="{{ .URL }}">
+        {{ end }}
             <img src="{{ .Params.featuredImage | relURL }}" alt="">
-        </a>
+        {{ if not .Params.restrictToTeaser }}
+            </a>
+        {{ end}}
     </div>
 {{ end }}


### PR DESCRIPTION
From time to time, one does want to post a simple article without any stuff around it. **Such** "simple" that you don't even need a detail page… :)

This newly created parameter removes the link to the dedicated post page and the `h3` tag from the default content. It also implies the `noSummary` parameter, the content will be displayed formatted as intended. 

To give you an example how this will look, I add a screenshot from a featured picture post from my personal blog (in the making) – it does not contain any markup, so it's **really** simple… ;)

<img width="810" alt="teaser" src="https://user-images.githubusercontent.com/3541050/39707114-b7d15c3e-5213-11e8-8761-714933ecb0ca.png">

I use this parameter to migrate my old Facebook posts to my personal blog. I don't need any detail pages and I don't need headings in this case. I did not want to add a custom post type only because I had to overwrite the `default-content.html` anyway.


