### PR TITLE
Use site subtitle for title tag on homepage

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,7 +25,11 @@
         {{ end }}
 
         {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
-        <title>{{ block "title" . }}{{ .Site.Title }} {{ with .Title }} | {{ . }}{{ end }}{{ end }}</title>
+        <title>
+            {{ block "title" . }}
+                {{ .Site.Title }} | {{ if eq .Site.Title .Title }}{{ .Site.Params.subtitle }}{{ else }}{{ .Title }}{{ end }}
+            {{ end }}
+        </title>
     </head>
     <body class="bilberry-hugo-theme">
         {{ partial "topnav" . }}


### PR DESCRIPTION
The site subtitle is used with the site title when the site title and the page title is identical, e.g. on the homepage.

**Examples:**

In default configuration, my blog shows "_Marcel Kraus | Marcel Kraus_" on the homepage and "_Marcel Kraus | Über mich_" on the "About me" page.

With this PR, the site subtitle is used when site title and page title are identical. This results in the following output on the homepage: "_Marcel Kraus | Ein Leben zwischen iOS und Werkstatt_". It does not affect the other pages.