### PR TITLE
Added support for Twitter metadata specification

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,6 +17,7 @@
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.2.1/dist/instantsearch.min.css">
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/instantsearch.js@2.2.1/dist/instantsearch-theme-algolia.min.css">
 
+        {{ partial "twitter-card" . }}
 
         {{ if isset .Site.Params "css_modules" }}
             {{ range .Site.Params.css_modules }}

--- a/layouts/partials/twitter-card.html
+++ b/layouts/partials/twitter-card.html
@@ -1,0 +1,31 @@
+{{ with .Params.twitter }}
+    <meta name="twitter:card" content="{{- .card -}}">
+    <meta name="twitter:site" content="{{- .site -}}">
+    {{ if ne .card "app" -}}
+    <meta name="twitter:title" content="{{- .title -}}">
+    <meta name="twitter:image" content="{{- .image -}}">
+    {{ with .image_alt -}}<meta name="twitter:image:alt" content="{{- . -}}">{{- end }}
+    {{- end }}
+    {{ with .creator -}}<meta name="twitter:creator" content="{{- . -}}">{{- end }}
+
+    {{- if eq .card "app" }}
+    {{ with .app_country }}<meta name="twitter:app:country" content="{{- . -}}">{{ end }}
+    {{ with .app_name_iphone }}<meta name="twitter:app:name:iphone" content="{{- . -}}">{{ end }}
+    {{ with .app_id_iphone }}<meta name="twitter:app:id:iphone" content="{{- . -}}">{{ end }}
+    {{ with .app_url_iphone }}<meta name="twitter:app:url:iphone" content="{{- . -}}">{{ end }}
+    {{ with .app_name_ipad }}<meta name="twitter:app:name:ipad" content="{{- . -}}">{{ end }}
+    {{ with .app_id_ipad }}<meta name="twitter:app:id:ipad" content="{{- . -}}">{{ end }}
+    {{ with .app_url_ipad }}<meta name="twitter:app:url:ipad" content="{{- . -}}">{{ end }}
+    {{ with .app_name_googleplay }}<meta name="twitter:app:name:googleplay" content="{{- . -}}">{{ end }}
+    {{ with .app_id_googleplay }}<meta name="twitter:app:id:googleplay" content="{{- . -}}">{{ end }}
+    {{ with .app_url_googleplay }}<meta name="twitter:app:url:googleplay" content="{{- . -}}">{{ end }}
+    {{- end }}
+
+    {{- if eq .card "player" }}
+    {{ with .player }}<meta name="twitter:player" content="{{- . -}}">{{ end }}
+    {{ with .player_width }}<meta name="twitter:player:width" content="{{- . -}}">{{ end }}
+    {{ with .player_height }}<meta name="twitter:player:height" content="{{- . -}}">{{ end }}
+    {{ with .player_stream }}<meta name="twitter:player:stream" content="{{- . -}}">{{ end }}
+    {{ with .player_stream_content_type }}<meta name="twitter:player:stream:content_type" content="{{- . -}}">{{ end }}
+    {{- end }}
+{{ end }}


### PR DESCRIPTION
I recently noticed that when posting a blog post to Twitter the metadata would not be rendered in the Twitter card format - in this pull request I followed the gohugohq Twitter card tutorial at : https://gohugohq.com/partials/twitter-cards-partials-for-hugo/ and added a partial called twitter-card.html as specified in the tutorial and included the partial in the default template file. Now one can specify Twitter metadata in their posts as shown below, and the Twitter cards are rendered correctly:

```
twitter:
  card: "summary"
  site: "@handle"
  title: "Post title"
  description: "Post description"
  image: "http://example.com/example.jpg"
```