### PR TITLE
Adding RSS Support

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -98,6 +98,6 @@ disqusShortname = "bilberry-hugo-theme"
   category = "categories"
 
 [outputs]
-  home = [ "HTML", "JSON" ]
+  home = [ "HTML", "JSON", "RSS" ]
   page = [ "HTML" ]
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,6 +12,11 @@
         <link rel="icon" type="image/png" href="{{ "favicon-32x32.png" | absURL }}" sizes="32x32">
         <link rel="icon" type="image/png" href="{{ "favicon-16x16.png" | absURL }}" sizes="16x16">
 
+	{{ if .RSSLink }}
+	  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+	  <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+	{{ end }}
+
         <link rel="stylesheet" href="{{ "dist/theme.css" | absURL }}">
 
         {{ partial "twitter-card" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -95,6 +95,10 @@
                 {{ end }}
                 {{ .Site.Params.copyrightBy | default "by Lednerb" }}
             </a>
+	    -
+	    {{ with  .OutputFormats.Get "rss" -}}
+		<a href="{{ .Permalink }}">{{ .Name }}</a>
+	    {{- end }}
         </div>
         <div class="author">
             <a href="{{ .Site.Params.creditsUrl | default "https://github.com/Lednerb/bilberry-hugo-theme" }}" target="_blank">{{ .Site.Params.creditsText | default "Bilberry Hugo Theme" }}</a>


### PR DESCRIPTION
Now if you set `home = [ "HTML", "JSON", "RSS" ]` in your `[outputs]` section of `config.toml` a RSS link will appear in the footer.