### PR TITLE
Allow pages to declare custom icons, overriding the default

### DIFF
--- a/layouts/partials/content-type/article.html
+++ b/layouts/partials/content-type/article.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-pencil"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-pencil" }}"></i>
 </a>
 
 <article class="default article">

--- a/layouts/partials/content-type/audio.html
+++ b/layouts/partials/content-type/audio.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-music"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-music" }}"></i>
 </a>
 
 <article class="audio">

--- a/layouts/partials/content-type/code.html
+++ b/layouts/partials/content-type/code.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-code"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-code" }}"></i>
 </a>
 
 <article class="default article">

--- a/layouts/partials/content-type/gallery.html
+++ b/layouts/partials/content-type/gallery.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-camera"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-camera" }}"></i>
 </a>
 
 <article class="gallery">

--- a/layouts/partials/content-type/link.html
+++ b/layouts/partials/content-type/link.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .Params.link }}" target="_blank">
-    <i class="fa fa-fw fa-link"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-link" }}"></i>
 </a>
 
 <article class="link">

--- a/layouts/partials/content-type/page.html
+++ b/layouts/partials/content-type/page.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-file"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-file" }}"></i>
 </a>
 
 <article class="default article">

--- a/layouts/partials/content-type/picture.html
+++ b/layouts/partials/content-type/picture.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-camera"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-camera" }}"></i>
 </a>
 
 <article class="picture">

--- a/layouts/partials/content-type/quote.html
+++ b/layouts/partials/content-type/quote.html
@@ -1,5 +1,5 @@
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-quote-right"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-quote-right" }}"></i>
 </a>
 
 <article class="quote">

--- a/layouts/partials/content-type/video.html
+++ b/layouts/partials/content-type/video.html
@@ -1,5 +1,6 @@
+
 <a class="bubble" href="{{ .URL }}">
-    <i class="fa fa-fw fa-video-camera"></i>
+    <i class="fa fa-fw {{or .Params.icon "fa-video-camera" }}"></i>
 </a>
 
 <article class="video">


### PR DESCRIPTION
Allow individual pages to override the present icons, by specifying the desired icon in the `icon:` parameter in the page markdown. 