### PR TITLE
Display an optional "pinned" post

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -65,6 +65,8 @@ disqusShortname = "bilberry-hugo-theme"
   # Content configuration
     # Enable an optional pinned page to display at the top of the index
     # pinnedPost = "/content/github/"
+    # Set to true to pin only to the first page, false to all pages
+    # pinOnlyToFirstPage = true
 
     # enable automatical localization of the article's PublishedDate with momentjs
     enableMomentJs = true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -63,6 +63,9 @@ disqusShortname = "bilberry-hugo-theme"
     showHeaderLanguageChooser = true
 
   # Content configuration
+    # Enable an optional pinned page to display at the top of the index
+    # pinnedPost = "/content/github/"
+
     # enable automatical localization of the article's PublishedDate with momentjs
     enableMomentJs = true
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,12 +1,17 @@
 {{ define "main" }}
 
+{{ $paginator := .Paginate (where .Data.Pages "Type" "ne" "page") (index .Site.Params "paginate" | default 7) }}
+
     {{ if .Site.Params.pinnedPost }}
-        {{ range first 1 (where .Data.Pages "URL" .Site.Params.pinnedPost) }}
-            {{ partial "article-wrapper" . }}
+        {{ if (and .Site.Params.pinOnlyToFirstPage (ne $paginator.PageNumber 1)) }}
+            {{/* Do nothing if the pinOnlyToFirstPage flag is set and we're not on page 1. */}}
+        {{else}}
+            {{ range first 1 (where .Data.Pages "URL" .Site.Params.pinnedPost) }}
+                {{ partial "article-wrapper" . }}
+            {{end}}
         {{end}}
     {{end}}
 
-    {{ $paginator := .Paginate (where .Data.Pages "Type" "ne" "page") (index .Site.Params "paginate" | default 7) }}
     {{ range  where .Paginator.Pages "Type" "ne" "page" }}
         {{ partial "article-wrapper" . }}
     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,13 +1,14 @@
 {{ define "main" }}
+
+    {{ if .Site.Params.pinnedPost }}
+        {{ range first 1 (where .Data.Pages "URL" .Site.Params.pinnedPost) }}
+            {{ partial "article-wrapper" . }}
+        {{end}}
+    {{end}}
+
     {{ $paginator := .Paginate (where .Data.Pages "Type" "ne" "page") (index .Site.Params "paginate" | default 7) }}
     {{ range  where .Paginator.Pages "Type" "ne" "page" }}
-        <div class="article-wrapper u-cf">
-            {{  if or (fileExists (print "layouts/partials/content-type/" .Type ".html") ) (fileExists (print "themes/bilberry-hugo-theme/layouts/partials/content-type/" .Type ".html")) }}
-                {{ partial (print "content-type/" .Type) . }}
-            {{ else }}
-                {{ partial "content-type/article" . }}
-            {{ end }}
-        </div>
+        {{ partial "article-wrapper" . }}
     {{ end }}
 
     {{ partial "paginator" . }}

--- a/layouts/partials/article-wrapper.html
+++ b/layouts/partials/article-wrapper.html
@@ -1,0 +1,9 @@
+{{ with . }}
+    <div class="article-wrapper u-cf">
+        {{ if or (fileExists (print "layouts/partials/content-type/" .Type ".html") ) (fileExists (print "themes/bilberry-hugo-theme/layouts/partials/content-type/" .Type ".html")) }}
+            {{ partial (print "content-type/" .Type) . }}
+        {{ else }}
+            {{ partial "content-type/article" . }}
+        {{ end }}
+    </div>
+{{end}}


### PR DESCRIPTION
Add the ability to display an optional "pinned" post at the top of the index page. 

The pinned post can be configured via the variable `pinnedPost` in `config.toml`. It must point to a valid post.

This can be used in combination https://github.com/Lednerb/bilberry-hugo-theme/pull/116 to set the icon of the pinned post to `fa-thumb-tack`. 