### PR TITLE
Exclude pages from index page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $paginator := .Paginate (where .Data.Pages "Type" "ne" "page") (index .Site.Params "paginate" | default 7) }}
+{{ $paginator := .Paginate (where .Site.RegularPages "Type" "ne" "page" | intersect (where .Site.RegularPages "Params.excludefromindex" "==" nil)) (index .Site.Params "paginate" | default 7) }}
 
     {{ if .Site.Params.pinnedPost }}
         {{ if (and .Site.Params.pinOnlyToFirstPage (ne $paginator.PageNumber 1)) }}
@@ -12,7 +12,7 @@
         {{end}}
     {{end}}
 
-    {{ range  where .Paginator.Pages "Type" "ne" "page" }}
+    {{ range $paginator.Pages }}
         {{ partial "article-wrapper" . }}
     {{ end }}
 


### PR DESCRIPTION
Add an option to exclude pages from the index by adding `excludeFromIndex: true` to the page definition. 

In its current state, this PR depends on https://github.com/Lednerb/bilberry-hugo-theme/pull/117 to minimize merge conflicts if both are accepted. 

I'm happy to pull out the changes from this PR into its own commit if you want to accept without accepting the pinned pages PR. 