### PR TITLE
Resolve DEPRECATION WARNING

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -37,7 +37,7 @@ $meta-border-color: #eee;
 $continue-reading-hover-color: $meta-text-color;
 
 $footer-border-color: #eee;
-$footer-background-color: #ffffff80;
+$footer-background-color: rgba(#ffffff, 80);
 $footer-headline-color: #444;
 
 


### PR DESCRIPTION
Resolve the following warning when running `hugo server`:

```
DEPRECATION WARNING on line 40, column 36 of /Users/nina/projects/nnja-io/themes/bilberry-hugo-theme/assets/sass/_variables.scss:
The value "#ffffff80" is currently parsed as a string, but it will be parsed as a color in
future versions of Sass. Use "unquote('#ffffff80')" to continue parsing it as a string.
```