### PR TITLE
Add trailing slash for tag links

### DIFF
--- a/layouts/partials/article-footer.html
+++ b/layouts/partials/article-footer.html
@@ -9,7 +9,7 @@
             <i class="fa fa-tags"></i>
             <div class="links">
                 {{ range . }}
-                    <a href="{{ (print "/tags/" (. | urlize)) | relLangURL }}">{{ . }}</a>
+                    <a href="{{ (print "/tags/" (. | urlize)) | relLangURL }}/">{{ . }}</a>
                 {{ end }}
             </div>
         </div>


### PR DESCRIPTION
I had issues because of this and according to [this page](https://discourse.gohugo.io/t/hugo-support-for-urls-without-a-trailing-slash/6763) it seems that using trailing slash is the supported way to generate URLs.