### PR TITLE
feat: keep tag casing as defined

### DIFF
--- a/layouts/_default/tag.terms.html
+++ b/layouts/_default/tag.terms.html
@@ -12,7 +12,7 @@
                 <hr>
                 <ul id="all-categories">
                     {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-                        <li><a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}">{{ $name | humanize }} ({{ $taxonomy.Count }})</a></li>
+                        <li><a href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}">{{ $name }} ({{ $taxonomy.Count }})</a></li>
                     {{ end }}
                 </ul>
             </div>


### PR DESCRIPTION
Hey @Lednerb not sure what your opinion is on this; but I would prefer the tags to not be modified regarding the case.
Currently it feels inconsistent that tags within the post overview are shown as defined e.g. `CI/CD`
![screenshot 2019-02-19 at 23 29 08](https://user-images.githubusercontent.com/7142618/53052180-47777900-349e-11e9-9f9f-8988583e9ab9.png)

but in the tag overview they are _humanized_ which turns `CI/CD` int`Ci/cd` which feels wrong :)
![screenshot 2019-02-19 at 23 29 11](https://user-images.githubusercontent.com/7142618/53052179-47777900-349e-11e9-99e8-5dc393af8f12.png)

I would prefer if they stayed the same as I define them in the posts, so behavior1, this PR will make sure the post overview also acts the same way as the individual tags are displayed on the post overview
