### PR TITLE
Fix default lang search didn't included bug

### DIFF
--- a/i18n/lo.toml
+++ b/i18n/lo.toml
@@ -8,10 +8,10 @@ other = "ຜູ້ຂຽນ"
 other = "ບົດຄວາມລ່າສຸດ"
 
 [search]
-other = "ຄົ້ນຫາ..."
+other = "ຄົ້ນຫາ ..."
 
 [noSearchResults]
-other = "ບໍ່ພົບສິ່ງທີ່ຄົ້ນຫາ"
+other = "ບໍ່ພົບສິ່ງທີ່ຄົ້ນຫາ."
 
 [olderPosts]
 other = "ບົດຄວາມເກົ່າກວ່າ"
@@ -20,7 +20,7 @@ other = "ບົດຄວາມເກົ່າກວ່າ"
 other = "ບົດຄວາມໃໝ່ຫວ່າ"
 
 [continueReading]
-other = "ອ່ານເພີ່ມ..."
+other = "ອ່ານເພີ່ມ"
 
 [otherLanguages]
 other = "ພາສາອື່ນ"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -14,10 +14,10 @@ other = "Redes sociais"
 other = "Últimos posts"
 
 [search]
-other = "Pesquisar..."
+other = "Pesquisar ..."
 
 [noSearchResults]
-other = "Nenhum resultado"
+other = "Nenhum resultado."
 
 [olderPosts]
 other = "Posts mais antigos"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -14,7 +14,7 @@ other = "Социальные медиа"
 other = "Последние записи"
 
 [search]
-other = "Поиск..."
+other = "Поиск ..."
 
 [noSearchResults]
 other = "Ничего не найдено."
@@ -26,7 +26,7 @@ other = "Старые записи"
 other = "Новые записи"
 
 [continueReading]
-other = "Читать далее..."
+other = "Читать далее"
 
 [otherLanguages]
 other = "Другие языки"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -14,7 +14,7 @@ other = "Sosyal medya"
 other = "Son gönderiler"
 
 [search]
-other = "Ara..."
+other = "Ara ..."
 
 [noSearchResults]
 other = "Hiçbir şey bulunamadı."

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -14,10 +14,10 @@ other = "社交媒体"
 other = "最新帖子"
 
 [search]
-other = "搜索"
+other = "搜索 ..."
 
 [noSearchResults]
-other = "什么都没找到"
+other = "什么都没找到。"
 
 [olderPosts]
 other = "以前的帖子"

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -14,7 +14,7 @@ other = "社交媒體"
 other = "最新文章"
 
 [search]
-other = "搜尋..."
+other = "搜尋 ..."
 
 [noSearchResults]
 other = "什麼都沒找到。"

--- a/layouts/index.json
+++ b/layouts/index.json
@@ -12,25 +12,27 @@
     {{- $.Scratch.Add "index" (dict "url" (print "/tags/" $name | absURL) "title" ($name | humanize) "iconClass" "fa-tag" "type" "tag" "objectID" (print "/tags/" $name | absURL) ) -}}
 {{- end -}}
 
-{{- range where .Pages "Type" "not in"  (slice "page" "json") -}}
+{{- range .Site.RegularPages -}}
 
-    {{- range .Translations -}}
-
-        {{- .Scratch.Set "iconClass" "fa-pencil" -}}
-        {{- if eq .Type "quote" -}}
-            {{- .Scratch.Set "iconClass" "fa-quote-right" -}}
-        {{- else if eq .Type "link" -}}
-            {{- .Scratch.Set "iconClass" "fa-link" -}}
-        {{- else if eq .Type "video" -}}
-            {{- .Scratch.Set "iconClass" "fa-video-camera" -}}
-        {{- else if or (eq .Type "gallery") (eq .Type "picture") -}}
-            {{- .Scratch.Set "iconClass" "fa-camera" -}}
-        {{- else if eq .Type "audio" -}}
-            {{- .Scratch.Set "iconClass" "fa-music" -}}
-        {{- end -}}
-
-        {{- $.Scratch.Add "index" (dict "url" .Permalink "title" .Title "tags" .Params.tags "categories" .Params.categories "author" .Params.author "type" .Type "language" .Lang "iconClass" (.Scratch.Get "iconClass") "objectID" (.Permalink | md5) ) -}}
+    {{-  $iconClass := "fa-pencil" -}}
+    {{- if eq .Type "quote" -}}
+        {{- $iconClass = "fa-quote-right" -}}
+    {{- else if eq .Type "link" -}}
+        {{- $iconClass = "fa-link" -}}
+    {{- else if eq .Type "video" -}}
+        {{- $iconClass = "fa-video-camera" -}}
+    {{- else if or (eq .Type "gallery") (eq .Type "picture") -}}
+        {{- $iconClass = "fa-camera" -}}
+    {{- else if eq .Type "audio" -}}
+        {{- $iconClass = "fa-music" -}}
     {{- end -}}
+        
+    {{- range .Translations -}}
+        {{- $.Scratch.Add "index" (dict "url" .Permalink "title" .Title "tags" .Params.tags "categories" .Params.categories "author" .Params.author "type" .Type "language" .Lang "iconClass" $iconClass "objectID" (.Permalink | md5) ) -}}
+    {{- end -}}
+    
+    {{- $.Scratch.Add "index" (dict "url" .Permalink "title" .Title "tags" .Params.tags "categories" .Params.categories "author" .Params.author "type" .Type "language" .Lang "iconClass" $iconClass "objectID" (.Permalink | md5) ) -}}
+        
 {{- end -}}
 
 {{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
In index.json, range .Pages with range .Translations only include translated pages, so outter range should add regular pages.
Besides, formatted translations.