### PR TITLE
feat: hide pages with draft:true from index and RSS feed

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 
-{{ $paginator := .Paginate (where .Site.RegularPages "Type" "ne" "page" | intersect (where .Site.RegularPages "Params.excludefromindex" "==" nil)) (index .Site.Params "paginate" | default 7) }}
+{{ $paginator := .Paginate (where (where .Site.RegularPages "Type" "ne" "page" | intersect (where .Site.RegularPages "Params.excludefromindex" "==" nil)) ".Params.draft" "ne" true) (index .Site.Params "paginate" | default 7) }}
 
     {{ if .Site.Params.pinnedPost }}
         {{ if (and .Site.Params.pinOnlyToFirstPage (ne $paginator.PageNumber 1)) }}

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -12,7 +12,7 @@
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range where .Pages "Type" "!=" "page" }}
+    {{ range where (where .Pages "Type" "!=" "page") ".Params.draft" "ne" true }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
Even though the bilberry [archetypes](https://github.com/Lednerb/bilberry-hugo-theme/blob/master/archetypes/default.md) define the `draft` attribute it does not affect the rendering process.

This PR will hide entries with `draft: true` from both the HTML overview and the RSS feed.