### PR TITLE
use hugo global function and .URL deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ If you like this theme and/or use it for commercial purposes, please support me!
 
 ## Requirements
 
-**Hugo version >= 0.43 Extended**
+**Hugo version >= 0.53 Extended**
 
-This theme makes use of Hugo Pipes, and requires at least Hugo version 0.43 **extended**. Please follow the installation instructions for your platform [here](https://gohugo.io/getting-started/installing/).
+This theme makes use of Hugo Pipes, and requires at least Hugo version 0.53 **extended**. Please follow the installation instructions for your platform [here](https://gohugo.io/getting-started/installing/).
 
 ## Quick Start
 
@@ -247,7 +247,7 @@ Otherwise, your changes would be overwritten when you update to the latest theme
 
 
 ## Custom colors and fonts
-Bilberry uses SCSS for styling, and [Hugo Pipes](https://gohugo.io/hugo-pipes/introduction/) to dynamically create the combined and compressed production-ready stylesheets. Hugo Pipes requires Hugo version >= 0.43 **extended**. Find installation instructions for your platform [here](https://gohugo.io/getting-started/installing/).
+Bilberry uses SCSS for styling, and [Hugo Pipes](https://gohugo.io/hugo-pipes/introduction/) to dynamically create the combined and compressed production-ready stylesheets. Hugo Pipes requires Hugo version >= 0.53 **extended**. Find installation instructions for your platform [here](https://gohugo.io/getting-started/installing/).
 
 If you want to change any colors or fonts, you have follow these steps:
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
         <meta name="author" content="{{ .Site.Params.author }}">
         <meta name="description" content="{{ .Site.Params.description }}">
         <meta name="keywords" content="{{ .Site.Params.keywords }}">
-        {{ .Hugo.Generator }}
+        {{ hugo.Generator }}
         <title>{{ block "title" . }} {{ .Scratch.Get "title" }} | {{ .Site.Title }}{{ end }}</title>
         <meta name="description" content="{{ .Scratch.Get "description" }}">
         <meta itemprop="name" content="{{ .Scratch.Get "title" }}">
@@ -38,7 +38,7 @@
         <meta property="og:title" content="{{ .Scratch.Get "title" }}">
         <meta property="og:description" content="{{ .Scratch.Get "description" }}">
         <meta property="og:image" content="{{ .Scratch.Get "image" }}">
-        <meta property="og:url" content="{{ .URL | absURL }}">
+        <meta property="og:url" content="{{ .Permalink | absURL }}">
         <meta property="og:site_name" content="{{ .Site.Title }}">
         {{- if .IsPage }}
         <meta property="og:type" content="article">
@@ -48,9 +48,9 @@
         <link rel="icon" type="image/png" href="{{ "favicon-32x32.png" | absURL }}" sizes="32x32">
         <link rel="icon" type="image/png" href="{{ "favicon-16x16.png" | absURL }}" sizes="16x16">
 
-	{{ if .RSSLink }}
-	  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-	  <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+	{{ if .RelPermalink }}
+	  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+	  <link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 	{{ end }}
 
         {{ $variables := resources.Get "sass/_variables.scss" }}

--- a/layouts/partials/content-type/article.html
+++ b/layouts/partials/content-type/article.html
@@ -1,4 +1,4 @@
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-pencil" }}"></i>
 </a>
 

--- a/layouts/partials/content-type/audio.html
+++ b/layouts/partials/content-type/audio.html
@@ -1,4 +1,4 @@
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-music" }}"></i>
 </a>
 

--- a/layouts/partials/content-type/code.html
+++ b/layouts/partials/content-type/code.html
@@ -1,4 +1,4 @@
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-code" }}"></i>
 </a>
 

--- a/layouts/partials/content-type/gallery.html
+++ b/layouts/partials/content-type/gallery.html
@@ -1,4 +1,4 @@
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-camera" }}"></i>
 </a>
 

--- a/layouts/partials/content-type/page.html
+++ b/layouts/partials/content-type/page.html
@@ -1,4 +1,4 @@
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-file" }}"></i>
 </a>
 

--- a/layouts/partials/content-type/picture.html
+++ b/layouts/partials/content-type/picture.html
@@ -1,4 +1,4 @@
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-camera" }}"></i>
 </a>
 

--- a/layouts/partials/content-type/quote.html
+++ b/layouts/partials/content-type/quote.html
@@ -1,4 +1,4 @@
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-quote-right" }}"></i>
 </a>
 

--- a/layouts/partials/content-type/video.html
+++ b/layouts/partials/content-type/video.html
@@ -1,5 +1,5 @@
 
-<a class="bubble" href="{{ .URL }}">
+<a class="bubble" href="{{ .Permalink }}">
     <i class="fa fa-fw {{or .Params.icon "fa-video-camera" }}"></i>
 </a>
 

--- a/layouts/partials/default-content.html
+++ b/layouts/partials/default-content.html
@@ -1,5 +1,5 @@
 <div class="content">
-    <h3><a href="{{ .URL }}">{{ .Title }}</a></h3>
+    <h3><a href="{{ .Permalink }}">{{ .Title }}</a></h3>
     <div class="meta">
         {{ if ( .Params.showDate | default true ) }}
             {{ if (.Site.Params.enableMomentJs | default true ) }}
@@ -32,7 +32,7 @@
         {{ .Summary }}
 
         {{ if .Truncated }}
-            <a href="{{ .URL }}" class="more">{{ i18n "continueReading" }}</a>
+            <a href="{{ .Permalink }}" class="more">{{ i18n "continueReading" }}</a>
         {{ end }}
     {{ end }}
 </div>

--- a/layouts/partials/featured-image.html
+++ b/layouts/partials/featured-image.html
@@ -1,6 +1,6 @@
 {{ if .Resources.GetMatch "featuredImage.*" }}
     <div class="featured-image">
-        <a href="{{ .URL }}">
+        <a href="{{ .Permalink }}">
             {{ if and (.Site.Params.resizeImages | default true) (.Params.resizeImages | default true) }}
                 <img src="{{ ((.Resources.GetMatch "featuredImage.*").Fill "700x350 q95").RelPermalink }}" alt="">
             {{ else }}
@@ -10,7 +10,7 @@
     </div>
 {{ else if and (isset .Params "featuredimage") (ne .Params.featuredImage "") }}
     <div class="featured-image">
-        <a href="{{ .URL }}">
+        <a href="{{ .Permalink }}">
             <img src="{{ .Params.featuredImage | relURL }}" alt="">
         </a>
     </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
                 <ul>
                 {{ range where (where (first (.Site.Params.amountLatestPostsInFooter | default 7) .Site.Pages.ByPublishDate.Reverse) ".Kind" "page") ".Type" "ne" "page" }}
                     <li>
-                        <a href="{{ .URL }}">{{ .Title }}</a>
+                        <a href="{{ .Permalink }}">{{ .Title }}</a>
                     </li>
                 {{ end }}
                 </ul>

--- a/layouts/partials/paginator.html
+++ b/layouts/partials/paginator.html
@@ -1,11 +1,11 @@
 {{ if ne .Paginator.TotalPages 0 }}
     <div class="paginator">
         {{ if .Paginator.HasNext }}
-            <a href="{{ .Paginator.Next.URL }}" class="older"><i class="fa fa-angle-double-left"></i> {{ i18n "olderPosts" }}</a>
+            <a href="{{ .Paginator.Next.Permalink }}" class="older"><i class="fa fa-angle-double-left"></i> {{ i18n "olderPosts" }}</a>
         {{ end }}
 
         {{ if .Paginator.HasPrev }}
-            <a href="{{ .Paginator.Prev.URL }}" class="newer">{{ i18n "newerPosts" }} <i class="fa fa-angle-double-right"></i></a>
+            <a href="{{ .Paginator.Prev.Permalink }}" class="newer">{{ i18n "newerPosts" }} <i class="fa fa-angle-double-right"></i></a>
         {{ end }}
     </div>
 {{ end }}

--- a/layouts/partials/topnav.html
+++ b/layouts/partials/topnav.html
@@ -11,7 +11,7 @@
                 {{ else if and (isset .Params "link") (ne .Params.link "") }}
                     <li><a href="{{ .Params.link | relURL }}" target="{{ .Params.target }}">{{ .Title }}</a></li>
                 {{ else }}
-                    <li><a href="{{ .URL }}">{{ .Title }}</a></li>
+                    <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
                 {{ end }}
             {{ end }}
         </ul>


### PR DESCRIPTION
v 0.54 runs fine, v 0.55 (recently released) however, returns:

 `WARN: Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.`
` WARN: Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.`
 
`WARN: Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like: 
    {{ with .OutputFormats.Get "RSS" }}{{ . RelPermalink }}{{ end }}.`

the only warning left would be  `Page's .GetParam is deprecated and will be removed in a future release. Use .Param or .Params.myParam`

this seems to fix it, the devs changed everything around 

