### PR TITLE
adds feature to allow custom social media links

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -120,6 +120,24 @@ disqusShortname = "bilberry-hugo-theme"
     xing       = ""
     linkedin   = ""
 
+    # To add custom links to your social media section, create a 'customlinks' map like below
+    # Currently only Font Awesome 4.7.0 icons are available
+    #
+    # customlinks = [
+    # 	{ link = "URL-ADDRESS", icon = "FONT-AWESOME-ICON-NAME" }, 
+    # 	{ link = "ANOTHER-URL", icon = "ANOTHER-FONT-AWESOME-ICON}, <--trailing comma intentional
+    #  ]
+      
+    customlinks = [ 
+	{ link = "https://gitlab.com/tonytheleg", icon = "fa fa-gitlab" },
+	{ link = "https://t.me/tonytheleg", icon = "fa fa-telegram"}, 
+	{ link = "https://steamcommunity.com/id/tonytheleg", icon = "fa fa-steam" },
+	{ link = "https://www.twitch.tv/tonytheleg", icon = "fa fa-twitch" }, 
+	{ link = "https://keybase.io/tonytheleg", icon = "fab fa-keybase" },
+    ]
+
+
+
     # credits line configuration
     copyrightBy = "by Lednerb"
     copyrightUseCurrentYear = false  # set to true to always display the current year in the copyright

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -120,23 +120,20 @@ disqusShortname = "bilberry-hugo-theme"
     xing       = ""
     linkedin   = ""
 
-    # To add custom links to your social media section, create a 'customlinks' map like below
-    # Currently only Font Awesome 4.7.0 icons are available
-    #
+    # Enable custom links in your social media section -- add to links to 'customlinks'below to use
+    showCustomSocialMedia = false
+
+    # Example custom links (currently supports FontAwesome 4.7.0 icons only)
+    # https://fontawesome.com/v4.7.0/icons/
+    # 
     # customlinks = [
-    # 	{ link = "URL-ADDRESS", icon = "FONT-AWESOME-ICON-NAME" }, 
-    # 	{ link = "ANOTHER-URL", icon = "ANOTHER-FONT-AWESOME-ICON}, <--trailing comma intentional
+    # 	{ link = "URL-ADDRESS", icon = "fa fa-icon" }, 
+    # 	{ link = "ANOTHER-URL", icon = "fa fa-anothericon}, <--trailing comma intentional
     #  ]
-      
+       
     customlinks = [ 
-	{ link = "https://gitlab.com/tonytheleg", icon = "fa fa-gitlab" },
-	{ link = "https://t.me/tonytheleg", icon = "fa fa-telegram"}, 
-	{ link = "https://steamcommunity.com/id/tonytheleg", icon = "fa fa-steam" },
-	{ link = "https://www.twitch.tv/tonytheleg", icon = "fa fa-twitch" }, 
-	{ link = "https://keybase.io/tonytheleg", icon = "fab fa-keybase" },
+	{ link = "", icon = "" }, 
     ]
-
-
 
     # credits line configuration
     copyrightBy = "by Lednerb"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -120,7 +120,7 @@ disqusShortname = "bilberry-hugo-theme"
     xing       = ""
     linkedin   = ""
 
-    # Enable custom links in your social media section -- add to links to 'customlinks'below to use
+    # Enable custom links in your social media section -- add your links to 'customlinks' below to use
     showCustomSocialMedia = false
 
     # Example custom links (currently supports FontAwesome 4.7.0 icons only)

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -67,9 +67,11 @@
                     <a href="{{ . }}" target="_blank"><i class="fa fa-linkedin"></i></a>
                 {{ end }}
             
-		{{ range .Site.Params.customlinks }}
-		    <a href="{{ .link }}" target="_blank"><i class="{{ .icon}}"></i></a>
-		{{ end {{
+		{{ if .Site.Params.showCustomSocialMedia | default false }}
+			{{ range .Site.Params.customlinks }}
+			    <a href="{{ .link }}" target="_blank"><i class="{{ .icon}}"></i></a>
+      	        	{{ end }}
+		{{ end }}
 	    </div>
             {{ end }}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -66,7 +66,11 @@
                 {{ with .Site.Params.linkedin }}
                     <a href="{{ . }}" target="_blank"><i class="fa fa-linkedin"></i></a>
                 {{ end }}
-            </div>
+            
+		{{ range .Site.Params.customlinks }}
+		    <a href="{{ .link }}" target="_blank"><i class="{{ .icon}}"></i></a>
+		{{ end {{
+	    </div>
             {{ end }}
 
             {{ if and (.Site.Params.showFooterLanguageChooser | default true) (gt .Site.Languages 1) }}


### PR DESCRIPTION
Addresses issue# #177 "Add gitlab to social media footer urls"
The changes made allow users to turn on custom social media icons and provide a list of URL's and font awesome icons. This addresses the issue and possible future requests for more sites. 