### PR TITLE
absolute url for og:image tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -38,7 +38,7 @@
     <meta itemprop="description" content="{{ .Scratch.Get "description" }}">
     <meta property="og:title" content="{{ .Scratch.Get "title" }}">
     <meta property="og:description" content="{{ .Scratch.Get "description" }}">
-    <meta property="og:image" content="{{ .Scratch.Get "image" }}">
+    <meta property="og:image" content="{{ .Scratch.Get "image" | absURL }}">
     <meta property="og:url" content="{{ .Permalink | absURL }}">
     <meta property="og:site_name" content="{{ .Site.Title }}">
     {{- if .IsPage }}


### PR DESCRIPTION
Sorry for all the bad pull requests that I have made yesterday.

If you use a relative URL in the featured image it will be in the `og:image` tag. Twitter and Facebook are not able to reach the image with the relative URL, so they display nothing as an image.

It solves issue #168 with all websites that use [open graph](https://ogp.me/) protocol.