### PR TITLE
New option for video content: play directly mp4 video

### DIFF
--- a/archetypes/video.md
+++ b/archetypes/video.md
@@ -9,4 +9,7 @@ author: ""
 # Set your video id for
 youtube: ""     # https://www.youtube.com/watch?v=M7IjJiZUutk -> "M7IjJiZUutk"
 vimeo: ""       # https://vimeo.com/239830182 -> "239830182"
+
+mp4video: ""        #location video file (only mp4)
+mp4videoImage: ""   #location poster image
 ---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,12 +1,13 @@
-{{- if not .Params.gallery -}}
-{{- if not .Params.featuredImage -}}
-{{ .Scratch.Set "image" (printf "https://www.gravatar.com/avatar/%s?size=200" (md5 .Site.Params.gravatarEMail)) }}
-{{- else -}}
-{{ .Scratch.Set "image" (.Params.featuredImage) }}
-{{- end -}}
-{{- else -}}
-{{ .Scratch.Set "image" (index (.Params.gallery) 0 | relURL | absURL) }}
-{{- end -}}
+{{ if .Params.gallery }}
+  {{ .Scratch.Set "image" (index (.Params.gallery) 0 | relURL | absURL) }}
+{{ else if .Params.featuredImage }}
+  {{ .Scratch.Set "image" (.Params.featuredImage) }}
+{{ else if .Params.mp4videoImage }}
+  {{ .Scratch.Set "image" (.Params.mp4videoImage) }}
+{{ else }}
+  {{ .Scratch.Set "image" (printf "https://www.gravatar.com/avatar/%s?size=200" (md5 .Site.Params.gravatarEMail)) }}
+{{ end }}
+
 {{- if ne .Description "" -}}
 {{ .Scratch.Set "description" (.Description) }}
 {{- else -}}

--- a/layouts/partials/content-type/video.html
+++ b/layouts/partials/content-type/video.html
@@ -23,6 +23,15 @@
     </div>
     {{ end }}
 
+    {{ if isset .Params "mp4video" }}
+    <div class="responsive-video local">
+      <video width="100%" controls poster="{{ .Params.mp4videoImage }}">
+        <source src="{{ .Params.mp4video }}" type="video/mp4">
+        Your browser does not support the video tag.
+      </video>
+    </div>
+    {{ end }}
+    
     {{ partial "default-content.html" . }}
     {{ partial "article-footer" . }}
 </article>


### PR DESCRIPTION
I have added two new parameters for the video content. They allow to play directly a mp4 file (locally or remote), using the video HTML tag.

- `mp4video`: the path to mp4 video file
- `mp4videoImage`: poster image for the video (optional)

If `mp4videoImage` exist it well be used for the Open Graph tag `og:image`.