### PR TITLE
Sharing sites backend

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -116,6 +116,23 @@ disqusShortname = "bilberry-hugo-theme"
       { link = "https://github.com/Lednerb", icon = "fab fa-github" },
     ]
 
+    # sharing sites on content footer
+    showSharing = true
+
+    # possible sharing sites, structure like social media.
+    # Add "SHARING_LINK" where you have to pace the permalink of the Content
+    # Add "SHARING_TEXT" where you want add the text in sharingText (not possible for every site)
+    sharingLinks = [
+      { link = "https://twitter.com/intent/tweet?text=SHARING_TEXT&url=SHARING_LINK", icon = "fab fa-twitter" },
+      { link = "https://facebook.com/sharer/sharer.php?u=SHARING_LINK", icon = "fab fa-facebook-f" },
+      { link = "mailto:?subject=SHARING_TEXT&body=SHARING_LINK", icon = "far fa-envelope" },
+      { link = "https://linkedin.com/shareArticle?mini=true&url=SHARING_LINK&title=SHARING_TEXT", icon = "fab fa-linkedin-in" },
+      { link = "whatsapp://send?text=SHARING_LINK", icon = "fab fa-whatsapp" },
+      { link = "https://telegram.me/share/url?text=SHARING_TEXT&  url=SHARING_LINK", icon = "fab fa-telegram-plane" },
+    ]
+
+    sharingText = "you can read this interesting article "
+
     # credits line configuration
     copyrightBy = "by Lednerb"
     copyrightUseCurrentYear = false  # set to true to always display the current year in the copyright
@@ -144,4 +161,3 @@ disqusShortname = "bilberry-hugo-theme"
 [outputs]
   home = [ "HTML", "JSON", "RSS" ]
   page = [ "HTML" ]
-

--- a/layouts/partials/sharing.html
+++ b/layouts/partials/sharing.html
@@ -1,0 +1,11 @@
+<!-- SHARING SITES -->
+{{ if .Site.Params.showSharing | default true }}
+  <div class="sharing-sites">
+        <i class="fa fa-share-alt-square"></i>
+
+        {{ range .Site.Params.sharingLinks }}
+          <a href="{{ replace ( replace .link "SHARING_LINK" $.Permalink ) "SHARING_TEXT" $.Site.Params.sharingText | safeURL }}" target="_blank"><i class="{{ .icon }}"></i></a>
+        {{ end }}
+
+    </div>
+{{ end }}


### PR DESCRIPTION
I have added the sharing possibility for content. The basic principle is like social media, a Font Awesome icon with a link to the sharing site  (`/layout/partials/sharing.html`). 

Some sites as only the possibility to send only a link, some others can add a text. Because they are all different there is a replacement for `SHARING_LINK` and `SHARING_TEXT`.

I have a big problem, I am a disaster with CSS. Can someone integrate this in the theme layout?