### PR TITLE
Update baseof.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -33,7 +33,15 @@
     <meta name="description" content="{{ .Site.Params.description }}">
     <meta name="keywords" content="{{ .Site.Params.keywords }}">
     {{ hugo.Generator }}
-    <title>{{ block "title" . }} {{ .Scratch.Get "title" }} | {{ .Site.Title }}{{ end }}</title>
+    <title>
+        {{ block "title" . }}
+           {{ if .Scratch.Get "title" }}
+               {{ .Scratch.Get "title" }} &vert; {{ .Site.Title }}
+           {{ else }}
+               {{ .Site.Title }}
+           {{ end }}
+        {{ end }}
+    </title>
     <meta name="description" content="{{ .Scratch.Get "description" }}">
     <meta itemprop="name" content="{{ .Scratch.Get "title" }}">
     <meta itemprop="description" content="{{ .Scratch.Get "description" }}">


### PR DESCRIPTION
The vertical bar should not be displayed in the home page title. For instance, currently, on my website (https://kiroule.com) the home page title is displayed as follows: "| Igor Baiborodine". With this fix, the vertical bar is not displayed in the home page title.