### PR TITLE
Fix capitalization of author's name in Authors page

### DIFF
--- a/layouts/_default/author.terms.html
+++ b/layouts/_default/author.terms.html
@@ -3,7 +3,7 @@
 <div class="content">
     <div class="article-wrapper u-cf single">
         <a class="bubble" href="{{ "/author/" | relLangURL}}">
-            <i class="fa fa-fw fa-users"></i>
+        <i class="fa fa-fw fa-users"></i>
         </a>
 
         <article class="article">
@@ -12,7 +12,9 @@
                 <hr>
                 <ul id="all-categories">
                     {{ range $name, $taxonomy := .Site.Taxonomies.author }}
-                        <li><a href="{{ "/author/" | relLangURL }}{{ $name | urlize }}">{{ $name | humanize }} ({{ $taxonomy.Count }})</a></li>
+                        {{- with site.GetPage (printf "/author/%s" (urlize $name)) -}}
+                            <li><a href="{{ .Permalink }}">{{ .Title}}({{ $taxonomy.Count }})</a></li>
+                        {{- end -}}
                     {{ end }}
                 </ul>
             </div>

--- a/layouts/_default/author.terms.html
+++ b/layouts/_default/author.terms.html
@@ -13,7 +13,7 @@
                 <ul id="all-categories">
                     {{ range $name, $taxonomy := .Site.Taxonomies.author }}
                         {{- with site.GetPage (printf "/author/%s" (urlize $name)) -}}
-                            <li><a href="{{ .Permalink }}">{{ .Title}}({{ $taxonomy.Count }})</a></li>
+                            <li><a href="{{ .Permalink }}">{{ .Title}} ({{ $taxonomy.Count }})</a></li>
                         {{- end -}}
                     {{ end }}
                 </ul>


### PR DESCRIPTION
The **humanize** function capitalizes only the first letter of the input string. Instead, use the author's page title to get the already capitalized author's name. 
Before the fix:
![image](https://user-images.githubusercontent.com/1027701/92115852-0cf3d980-edc1-11ea-9e61-19e81c1e5dbc.png)

After the fix:
![image](https://user-images.githubusercontent.com/1027701/92115940-29901180-edc1-11ea-8b6b-f7f3762cfdef.png)



