### PR TITLE
Fix capitalization of author's name in author index

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -5,7 +5,13 @@
 {{- end -}}
 
 {{- range $name, $taxonomy := .Site.Taxonomies.author -}}
-    {{- $.Scratch.Add "index" (dict "url" (print "/author/" $name | absURL) "title" ($name | humanize) "iconClass" "fa-user" "type" "author" "objectID" (print "/author/" $name | absURL) ) -}}
+    {{- $author_name := $name -}}
+    {{- $author_path := (printf "/author/%s" (urlize $name)) -}}
+    {{- $author_page := site.GetPage $author_path -}}
+    {{- if $author_page -}}
+        {{- $author_name = $author_page.Title -}}
+    {{- end -}}
+    {{- $.Scratch.Add "index" (dict "url" ($author_path | absURL) "title" $author_name "iconClass" "fa-user" "type" "author" "objectID" ($author_path | absURL) ) -}}
 {{- end -}}
 
 {{- range $name, $taxonomy := .Site.Taxonomies.tags -}}


### PR DESCRIPTION
**index.json**: the humanize function capitalizes only the first letter of the input string. Instead, use the author's page title to get the already capitalized author's name.

Before the fix:
![image](https://user-images.githubusercontent.com/1027701/92190673-bf628580-ee2f-11ea-8fa5-47aff5a4d2c5.png)

After the fix:
![image](https://user-images.githubusercontent.com/1027701/92190692-cbe6de00-ee2f-11ea-93e4-58f38e36ca2c.png)
