### PR TITLE
Fix broken pinned post feature, allow multiple pinned posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Posts can be customized via a variety of options.
 
 To exclude posts from appearing on your blog index, while still being displayed in categories, add `excludeFromIndex: true` to the post configuration.
 
-The theme also has options for a pinned post. Just uncomment `pinnedPost` in `config.toml`, and point it to the post you'd like permanently pinned to the top of the page. The `pinOnlyToFirstPage` setting lets you control if you'd like to only display the pinned post on the index, or on all pages.
+If you'd like to pin one or several posts to the top of the index page, uncomment the `pinnedPost` param in `config.toml`. Then set its value to the post's relative URL, for example, `/article/installing-bilberry-theme/`. When pinning multiple posts, the relative URL values should be separated by a comma. The `pinOnlyToFirstPage` parameter allows you to choose whether to display pinned posts on the index page only or on all pages.
 
 A custom icon can be declared per post, by specifying a font-awesome icon in the post configuration, such as `icon: fa-thumb-tack` for a pinned post.
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -79,7 +79,7 @@ disqusShortname = ""
 
   # Content configuration
     # Enable an optional pinned page to display at the top of the index
-    # pinnedPost = "/content/github/"
+    # pinnedPost = "/article/installing-bilberry-theme/"
     # Set to true to pin only to the first page, false to all pages
     # pinOnlyToFirstPage = true
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,14 +1,24 @@
 {{ define "main" }}
 {{ $allNonExcludedPages := where .Site.RegularPages "Params.excludefromindex" "==" nil }}
 {{ $allNonExcludedPagesNotTypePage := (where .Site.RegularPages "Type" "ne" "page" | intersect $allNonExcludedPages) }}
-{{ $paginator := .Paginate $allNonExcludedPagesNotTypePage (index .Site.Params "paginate" | default 7) }}
+
+{{ $pinnedPostRelPermalinks := split .Site.Params.pinnedPost "," }}
+{{ $pinnedPosts := where $allNonExcludedPagesNotTypePage "RelPermalink" "in" $pinnedPostRelPermalinks }}
+{{ $pagesToPaginate := where $allNonExcludedPagesNotTypePage "RelPermalink" "not in" $pinnedPostRelPermalinks }}
+
+{{ $paginationLimit := index .Site.Params "paginate" | default 7 }}
+{{ if not .Site.Params.pinOnlyToFirstPage }}
+    {{ $paginationLimit = sub $paginationLimit (len $pinnedPosts) }}
+{{ end }}
+
+{{ $paginator := .Paginate $pagesToPaginate $paginationLimit }}
 
     {{ if .Site.Params.pinnedPost }}
         {{ if (and .Site.Params.pinOnlyToFirstPage (ne $paginator.PageNumber 1)) }}
             {{/* Do nothing if the pinOnlyToFirstPage flag is set and we're not on page 1. */}}
         {{else}}
-            {{ range first 1 (where .Data.Pages "URL" .Site.Params.pinnedPost) }}
-                {{ partial "article-wrapper.html" . }}
+            {{ range $pinnedPosts }}
+        {{ partial "article-wrapper.html" . }}
             {{end}}
         {{end}}
     {{end}}

--- a/testing/testing-example-site/config.toml
+++ b/testing/testing-example-site/config.toml
@@ -76,7 +76,7 @@ disqusShortname = "bilberry-hugo-theme"
 
   # Content configuration
     # Enable an optional pinned page to display at the top of the index
-    # pinnedPost = "/content/github/"
+    # pinnedPost = "/article/installing-bilberry-theme/"
     # Set to true to pin only to the first page, false to all pages
     # pinOnlyToFirstPage = true
 


### PR DESCRIPTION
1. The pinned post feature was broken because the `.Data.Pages` command would return top-level pages(i.e., post types), for example, Articles, Videos, etc. 
2. On my website, I want to pin more than one post; therefore, I added this capability.
3. Also, when the pinned posts are displayed on all pages, I assured that the number of posts displayed does not exceed the paginate setting.
4. But when the pinned posts are displayed on the first page only, I could not find a viable solution so that the number of posts displayed does not exceed the paginate setting.

Test website URL: https://bilberry-toc-test.netlify.app/
Test website GitHub repo: https://github.com/igor-baiborodine/bilberry-toc-test

