### PR TITLE
last image fallback to site's customImage value

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,7 +26,7 @@
 {{ else if .Params.mp4videoImage }}
   {{ .Scratch.Set "image" (.Params.mp4videoImage | absURL) }}
 {{ else }}
-  {{ .Scratch.Set "image" (printf "https://www.gravatar.com/avatar/%s?size=200" (md5 .Site.Params.gravatarEMail)) }}
+  {{ .Scratch.Set "image" (site.Params.customImage) }}
 {{ end }}
 
 {{- if ne .Description "" -}}


### PR DESCRIPTION
if gravatar isn't used the site doesn't have a OG image and it uses a gravatar placeholder instead. With this it will fall back to what the user has defined as customImage in site's config.