### PR TITLE
Update baseof.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -90,6 +90,8 @@
 
     {{ with .Params.original_url }}
     <link rel=”canonical” href=”{{ . }}” />
+    {{ else }}
+    <link rel='canonical' href='{{ .Permalink }}'>
     {{ end }}
 
     <link rel="stylesheet" href="{{ "theme.css" | absURL }}">


### PR DESCRIPTION
if there is no original_url parameter the site should announce it's permalink. Need this in order to make telegram comments to work & I think it should be like this by w3 standard. I'm a noob, man.