### PR TITLE
Add setting for raw HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,14 @@ The second option is to use the `video` shortcode within markdown content in a p
 
 ```
 
+### Raw HTML
+If you want to include raw HTML in your markdown content, enable the `unsafe` setting in your `config.toml` file by changing it to `true`:
+```toml
+[markup.goldmark]
+  [markup.goldmark.renderer]
+    unsafe = true
+```
+
 ## Favicons
 Using favicons nowadays is not a trivial thing.
 There are many different sizes and file types for the various mobile and desktop browsers and for the shortcuts for Android and iOS devices.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,10 +14,6 @@ googleAnalytics = ""
 # Enable / Disable comments on the articles via Disqus.
 disqusShortname = ""
 
-# Enable / Disable open link with a new tab.
-[blackfriday]
-  hrefTargetBlank = false
-
 [params]
   # Custom CSS / JS modules that will be imported by the template.
   # Files are relative to the static/ directory or a URL.
@@ -162,6 +158,12 @@ disqusShortname = ""
   page = [ "HTML" ]
 
 [markup]
+  defaultMarkdownHandler = 'goldmark'
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      # Change to 'true' if you need to render raw HTML whithin your markdown content
+      unsafe = false
+
   [markup.tableOfContents]
     endLevel = 5
     ordered = false


### PR DESCRIPTION
This PR contains the following changes:
1. Removed redundant Blackfriday's `hrefTargetBlank` setting.
2. Added explicit setting for Goldmark as the default markdown.
3. Added setting for raw HTML. 

Tested at Bilberry Sandbox with raw HTML enabled.

https://www.bilberry-sandbox.kiroule.com/article/test-raw-html/