### PR TITLE
Turn bilberry theme into a hugo module

### DIFF
--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -1,0 +1,3 @@
+module github.com/Lednerb/billberry-hugo-theme-example
+
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Lednerb/bilberry-hugo-theme
+
+go 1.12


### PR DESCRIPTION
This PR turns the theme into a hugo module.
With `git`and `go` installed, making use of the bilberry theme is now as easy as:

```
hugo new site my_site
cd mysite
echo 'theme = "github.com/Lednerb/bilberry-hugo-theme"' >> config.toml
hugo server
```

Copying/cloning the theme in the themes folder is still possible of course.

If desired, I can extend the `Quickstart` section in `README.md`, explaining how to make use of the theme as module.

