### PR TITLE
fix: added missing french translation for article items

### DIFF
--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -35,3 +35,11 @@ other = "Autres langues"
 one = "1 Min. lecture"
 other = "{{.Count}} Min. lecture"
 
+[tableOfContents]
+other = "Table des Contenus"
+
+[series]
+other = "Séries"
+
+[archive]
+other = "Archives"


### PR DESCRIPTION
Here is some missing french translation on article items (table of contents...).