### PR TITLE
Display copyright years properly

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -72,8 +72,10 @@
                 &copy;
                 {{ if .Site.Params.copyrightUseCurrentYear }}
                 {{ now.Year }}
+                {{ else if gt now.Year (.Site.Params.copyrightYearOverride | default 2018) }}
+		{{ .Site.Params.copyrightYearOverride | default 2018 }} - {{ now.Year }}
                 {{ else }}
-                {{ .Site.Params.copyrightYearOverride | default 2018 }}
+		{{ .Site.Params.copyrightYearOverride | default 2018 }}
                 {{ end }}
                 {{ .Site.Params.copyrightBy | default "by Lednerb" }}
             </a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -73,9 +73,9 @@
                 {{ if .Site.Params.copyrightUseCurrentYear }}
                 {{ now.Year }}
                 {{ else if gt now.Year (.Site.Params.copyrightYearOverride | default 2018) }}
-		{{ .Site.Params.copyrightYearOverride | default 2018 }} - {{ now.Year }}
+                {{ .Site.Params.copyrightYearOverride | default 2018 }} - {{ now.Year }}
                 {{ else }}
-		{{ .Site.Params.copyrightYearOverride | default 2018 }}
+                {{ .Site.Params.copyrightYearOverride | default 2018 }}
                 {{ end }}
                 {{ .Site.Params.copyrightBy | default "by Lednerb" }}
             </a>


### PR DESCRIPTION
Copyright years should declare when it starts up to the most recent publication, with this code change it currently shows " © 2022 Rui Miguel Silva Seabra " but if I generate the web-site again from 2023 it will display " © 2022-2023 Rui Miguel Silva Seabra ", and in 2024 it will be " © 2022-2024" Rui Miguel Silva Seabra " and so forth.

My current related config is:
```
copyright: 'Copyright &copy; 2022-{year} Rui Miguel Silva Seabra'
copyrightBy: 'Rui Miguel Silva Seabra'
copyrightUseCurrentYear: false
copyrightYearOverride: 2022
copyrightUrl: '/info/'
```
