### PR TITLE
Top language switcher stays on the current page

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -44,18 +44,24 @@
             </div>
             {{ end }}
 
-            {{ if and (.Site.Params.showFooterLanguageChooser | default true) (gt .Site.Languages 1) }}
-            {{- $.Scratch.Set "language" .Language -}}
-            <div class="languages">
-                <strong>{{ i18n "otherLanguages" }}</strong>
-                {{ range $.Site.Home.AllTranslations }}
-                {{ if eq ($.Scratch.Get "language") .Language }}
-                <a href="{{ .Permalink }}" class="active">{{ .Language }}</a>
-                {{ else }}
-                <a href="{{ .Permalink }}">{{ .Language }}</a>
-                {{ end }}
-                {{ end }}
-            </div>
+            {{ if and (gt .Site.Languages 1) (.Site.Params.showFooterLanguageChooser | default true) }}
+                {{- $language := .Language -}}
+                {{- $pages := .Page.AllTranslations -}}
+                <div class="languages">
+                    <strong>{{ i18n "otherLanguages" }}</strong>
+                    {{ range $.Site.Home.AllTranslations }}
+                        {{ $url := .RelPermalink }}
+                        {{ range where $pages "Lang" .Language.Lang }}
+                            {{ $url = .RelPermalink }}
+                        {{ end }}
+
+                        {{ if eq $language .Language }}
+                            <a href="{{ $url }}" class="active">{{ .Language }}</a>
+                        {{ else }}
+                            <a href="{{ $url }}">{{ .Language }}</a>
+                        {{ end }}
+                    {{ end }}
+                </div>
             {{ end }}
 
             {{ if .Site.Params.showArchive | default true }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -37,18 +37,16 @@
             {{- $language := .Language -}}
             {{- $pages := .Page.AllTranslations -}}
             <div class="languages">
-            {{ range $site := $.Site.Home.AllTranslations }}
-                {{ $url := $site.RelPermalink }}
-                {{ range $page := $pages }}
-                    {{ if eq $page.Lang $site.Language.Lang }}
-                      {{ $url = $page.RelPermalink }}
-                    {{ end }}
+            {{ range $.Site.Home.AllTranslations }}
+                {{ $url := .RelPermalink }}
+                {{ range where $pages "Lang" .Language.Lang }}
+                  {{ $url = .RelPermalink }}
                 {{ end }}
 
-                {{ if eq $language $site.Language }}
-                    <a href="{{ $url }}" class="active">{{ $site.Language }}</a>
+                {{ if eq $language .Language }}
+                    <a href="{{ $url }}" class="active">{{ .Language }}</a>
                 {{ else }}
-                    <a href="{{ $url }}">{{ $site.Language }}</a>
+                    <a href="{{ $url }}">{{ .Language }}</a>
                 {{ end }}
             {{ end }}
             </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,11 +36,11 @@
         {{ if and (gt .Site.Languages 1) (.Site.Params.showHeaderLanguageChooser | default true) }}
             {{- $language := .Language -}}
             <div class="languages">
-            {{ range $.Site.Home.AllTranslations }}
+            {{ range .Page.AllTranslations }}
                 {{ if eq $language .Language }}
-                    <a href="{{ .Permalink }}" class="active">{{ .Language }}</a>
+                    <a href="{{ .RelPermalink }}" class="active">{{ .Language }}</a>
                 {{ else }}
-                    <a href="{{ .Permalink }}">{{ .Language }}</a>
+                    <a href="{{ .RelPermalink }}">{{ .Language }}</a>
                 {{ end }}
             {{ end }}
             </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -35,12 +35,20 @@
 
         {{ if and (gt .Site.Languages 1) (.Site.Params.showHeaderLanguageChooser | default true) }}
             {{- $language := .Language -}}
+            {{- $pages := .Page.AllTranslations -}}
             <div class="languages">
-            {{ range .Page.AllTranslations }}
-                {{ if eq $language .Language }}
-                    <a href="{{ .RelPermalink }}" class="active">{{ .Language }}</a>
+            {{ range $site := $.Site.Home.AllTranslations }}
+                {{ $url := $site.RelPermalink }}
+                {{ range $page := $pages }}
+                    {{ if eq $page.Lang $site.Language.Lang }}
+                      {{ $url = $page.RelPermalink }}
+                    {{ end }}
+                {{ end }}
+
+                {{ if eq $language $site.Language }}
+                    <a href="{{ $url }}" class="active">{{ $site.Language }}</a>
                 {{ else }}
-                    <a href="{{ .RelPermalink }}">{{ .Language }}</a>
+                    <a href="{{ $url }}">{{ $site.Language }}</a>
                 {{ end }}
             {{ end }}
             </div>


### PR DESCRIPTION
Hi,

I found it quite confusing that the language switcher at the top _does not_ stay on the same page, but instead throws me back at the home page.

Sure, we have the "page based" language selector at the bottom, but I doubt that the current situation is the most user friendly / intuitive one 😅 

So treat this PR as a friendly proposal 😄 