### PR TITLE
Add generic hook system

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -96,9 +96,16 @@
             <link rel="stylesheet" href="{{ . | absURL }}">
         {{ end }}
     {{ end }}
+
+    {{ if templates.Exists "partials/hook/head-end.html" }}
+        {{ partial "hook/head-end.html" }}
+    {{ end }}
 </head>
 
 <body class="bilberry-hugo-theme">
+    {{ if templates.Exists "partials/hook/body-start.html" }}
+        {{ partial "hook/body-start.html" }}
+    {{ end }}
 
     {{ partial "topnav.html" . }}
 
@@ -127,6 +134,10 @@
 
     {{ if and (isset .Site.Params "algolia_search") (eq .Site.Params.algolia_search true) }}
     {{ partial "algolia-search.html" . }}
+    {{ end }}
+
+    {{ if templates.Exists "partials/hook/body-end.html" }}
+        {{ partial "hook/body-end.html" }}
     {{ end }}
 </body>
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -97,15 +97,11 @@
         {{ end }}
     {{ end }}
 
-    {{ if templates.Exists "partials/hook/head-end.html" }}
-        {{ partial "hook/head-end.html" }}
-    {{ end }}
+    {{ partial "hooks/head-end.html" }}
 </head>
 
 <body class="bilberry-hugo-theme">
-    {{ if templates.Exists "partials/hook/body-start.html" }}
-        {{ partial "hook/body-start.html" }}
-    {{ end }}
+    {{ partial "hooks/body-start.html" }}
 
     {{ partial "topnav.html" . }}
 
@@ -136,9 +132,7 @@
     {{ partial "algolia-search.html" . }}
     {{ end }}
 
-    {{ if templates.Exists "partials/hook/body-end.html" }}
-        {{ partial "hook/body-end.html" }}
-    {{ end }}
+    {{ partial "hooks/body-end.html" }}
 </body>
 
 </html>

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,4 @@
+<!--
+    1. Copy this file into your site root's "layouts/partials/hooks" folder
+    2. Add the necessary code to integrate with third-party services or to customize your site further
+-->

--- a/layouts/partials/hooks/body-start.html
+++ b/layouts/partials/hooks/body-start.html
@@ -1,0 +1,4 @@
+<!--
+    1. Copy this file into your site root's "layouts/partials/hooks" folder
+    2. Add the necessary code to integrate with third-party services or to customize your site further
+-->

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,4 @@
+<!--
+    1. Copy this file into your site root's "layouts/partials/hooks" folder
+    2. Add the necessary code to integrate with third-party services or to customize your site further
+-->


### PR DESCRIPTION
**For context:**

Previously I opened another PR (https://github.com/Lednerb/bilberry-hugo-theme/pull/486) to add support for [umami](https://umami.is/) as analytics solution, which got closed.

I do totally understand that maintaining the integration with all the various tools out there (not only restricted to analytics) is nothing this theme can / should do! So no hard feeling here 😄 

**New suggestion:**

But this got me thinking, and that's why I'd like to propose this PR. Here I added a very simply "hook system", which would allow users to easily hook into the theme _without copying around and/or overwriting_ theme files.

IMHO overwriting theme files should really be the last resort, as this makes upgrading the theme quite cumbersome. But those 3 hooks would easily allow custom tool integrations while keeping "theme upgradability" 😎 