### PR TITLE
Trim down JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Please use the following guidelines if you want to start a discussion:
   - [Archive Page](#archive-page)
   - [Responsive Design](#responsive-design)
   - [MathJAX Markup](#mathjax-markup)
-  - [Disabled Javascript Support](#disabled-javascript-support)
+  - [Disabled JavaScript Support](#disabled-javascript-support)
+  - [Trimmed JavaScript size](#trimmed-javascript-size)
   - [Raw HTML](#raw-html)
 - [Customizations](#customizations)
   - [Favicons](#favicons)
@@ -745,7 +746,7 @@ Bilberry theme is optimized to look good on all devices, namely desktops, tablet
 To enable the [MathJAX](https://www.mathjax.org) markup support, set the `enable_mathjax` parameter to `true` in
 the `config.toml` file.
 
-### Disabled Javascript Support
+### Disabled JavaScript Support
 
 Although this theme has a lot of features that only work with enabled JavaScript, it also fully supports disabled
 JavaScript.
@@ -753,6 +754,18 @@ Disabled Javascript will not break any styling or essential functionalities of y
 
 You can test the behavior of the [demo site](https://lednerb.github.io/bilberry-hugo-theme) by disabling JavaScript in
 your browser.
+
+### Trimmed JavaScript size
+
+By default the JavaScript bundle of this theme contains both [highlightjs][] and [momentjs][] which are quite big, even though they add some real value.
+
+To save some bytes and trim down the size of the JavaScript bundle one can choose wether or not those feature should stay enabled (which is the current default), via two config parameters:
+
+```toml
+[params]
+enableHighlightJs = true # false would save ~127KiB gzipped
+enableMomentJs = true    # false would save ~262KiB gzipped
+```
 
 ### Raw HTML
 
@@ -926,3 +939,6 @@ of any kind welcome!
 ## License
 
 The Bilberry Hugo theme is licensed under the MIT license.
+
+  [highlightjs]: https://highlightjs.org/
+  [momentjs]: https://momentjs.com/

--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ your browser.
 
 By default the JavaScript bundle of this theme contains both [highlightjs][] and [momentjs][] which are quite big, even though they add some real value.
 
-To save some bytes and trim down the size of the JavaScript bundle one can choose wether or not those feature should stay enabled (which is the current default), via two config parameters:
+To save some bytes and trim down the size of the JavaScript bundle, one can choose wether or not those features should stay enabled (which is the current default), via two config parameters:
 
 ```toml
 [params]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Please use the following guidelines if you want to start a discussion:
   - [Responsive Design](#responsive-design)
   - [MathJAX Markup](#mathjax-markup)
   - [Disabled JavaScript Support](#disabled-javascript-support)
-  - [Trimmed JavaScript size](#trimmed-javascript-size)
   - [Raw HTML](#raw-html)
 - [Customizations](#customizations)
   - [Favicons](#favicons)

--- a/README.md
+++ b/README.md
@@ -756,9 +756,9 @@ your browser.
 
 ### Trimmed JavaScript Size
 
-By default the JavaScript bundle of this theme contains both [highlightjs][] and [momentjs][] which are quite big, even though they add some real value.
+By default, this theme's JavaScript bundle contains the [highlight.js](https://highlightjs.org/) and [Moment.js](https://momentjs.com/) libraries, which are pretty large, though they add real value.
 
-To save some bytes and trim down the size of the JavaScript bundle, one can choose wether or not those features should stay enabled (which is the current default), via two config parameters:
+Therefore, to reduce the size of the downloaded JavaScript bundle, you can choose whether these features should remain enabled (which is currently the default) via two configuration parameters
 
 ```toml
 [params]
@@ -938,6 +938,3 @@ of any kind welcome!
 ## License
 
 The Bilberry Hugo theme is licensed under the MIT license.
-
-  [highlightjs]: https://highlightjs.org/
-  [momentjs]: https://momentjs.com/

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Please use the following guidelines if you want to start a discussion:
   - [Archive Page](#archive-page)
   - [Responsive Design](#responsive-design)
   - [MathJAX Markup](#mathjax-markup)
-  - [Disabled JavaScript Support](#disabled-javascript-support)
+  - [Disabled Javascript Support](#disabled-javascript-support)
   - [Raw HTML](#raw-html)
 - [Customizations](#customizations)
   - [Favicons](#favicons)

--- a/README.md
+++ b/README.md
@@ -754,7 +754,7 @@ Disabled Javascript will not break any styling or essential functionalities of y
 You can test the behavior of the [demo site](https://lednerb.github.io/bilberry-hugo-theme) by disabling JavaScript in
 your browser.
 
-### Trimmed JavaScript size
+### Trimmed JavaScript Size
 
 By default the JavaScript bundle of this theme contains both [highlightjs][] and [momentjs][] which are quite big, even though they add some real value.
 

--- a/assets/js/highlight.js
+++ b/assets/js/highlight.js
@@ -1,0 +1,2 @@
+require('highlight.js')
+    .initHighlightingOnLoad();

--- a/assets/js/moment.js
+++ b/assets/js/moment.js
@@ -1,0 +1,14 @@
+require('jquery');
+
+let moment = require('moment');
+require("moment/min/locales.min");
+
+$(document).ready(function () {
+    let language = $('html').attr('lang');
+    moment.locale(language);
+
+    $('.moment').each(function() {
+        date = $(this).text()
+        $(this).text(moment(date).format('LL'))
+    });
+});

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -7,9 +7,6 @@ require('tooltipster');
 require('magnific-popup');
 
 let ClipboardJs = require('clipboard')
-let hljs = require('highlight.js');
-let moment = require('moment');
-require("moment/min/locales.min");
 
 // Add ClipboardJs to enable copy button functionality
 new ClipboardJs('.copy-button', {
@@ -223,14 +220,4 @@ $(document).ready(function () {
                 }
             });
     }
-
-    // MomentJS
-    language = $('html').attr('lang');
-    moment.locale(language);
-    $('.moment').each(function() {
-        date = $(this).text()
-        $(this).text(moment(date).format('LL'))
-    });
 });
-
-hljs.initHighlightingOnLoad();

--- a/assets/sass/_bilberry-hugo-theme.scss
+++ b/assets/sass/_bilberry-hugo-theme.scss
@@ -31,9 +31,13 @@
         }
     }
 
+    code {
+        background: transparent !important;
+    }
+
     pre {
         position: relative;
-        background: transparent !important;
+        background: transparent;
 
         code {
             padding: 1.0em;

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -107,6 +107,10 @@ disqusShortname = ""
     # Set to true to pin only to the first page, false to all pages
     # pinOnlyToFirstPage = true
 
+    # enable highlight.js for syntax highlighting or (if set to false) use
+    # the hugo built-in chroma highlighter
+    enableHighlightJs = false
+
     # enable automatic localization of the article's PublishedDate with momentjs
     enableMomentJs = true
 
@@ -182,6 +186,9 @@ disqusShortname = ""
     endLevel = 5
     ordered = false
     startLevel = 2
+
+  [markup.highlight]
+    style = "pastie"
 
 # do NOT change anything below
 [taxonomies]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -109,7 +109,7 @@ disqusShortname = ""
 
     # enable highlight.js for syntax highlighting or (if set to false) use
     # the hugo built-in chroma highlighter
-    enableHighlightJs = false
+    enableHighlightJs = true
 
     # enable automatic localization of the article's PublishedDate with momentjs
     enableMomentJs = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -119,11 +119,11 @@
     {{- $noMoment    := not (.Site.Params.enableMomentJs    | default true) -}}
     {{- $noHighlight := not (.Site.Params.enableHighlightJs | default true) -}}
     {{ if and $noMoment $noHighlight }}
-    <script src="{{ "theme-noMoment-noHighlight.js" | absURL }}"></script>
+    <script src="{{ "theme-no-moment-no-highlight.js" | absURL }}"></script>
     {{ else if $noMoment }}
-    <script src="{{ "theme-noMoment.js" | absURL }}"></script>
+    <script src="{{ "theme-no-moment.js" | absURL }}"></script>
     {{ else if $noHighlight }}
-    <script src="{{ "theme-noHighlight.js" | absURL }}"></script>
+    <script src="{{ "theme-no-highlight.js" | absURL }}"></script>
     {{ else }}
     <script src="{{ "theme.js" | absURL }}"></script>
     {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -116,12 +116,14 @@
     {{ partial "mathjax.html" . }}
     {{ end }}
 
-    {{ if and .Site.Params.enableMomentJs .Site.Params.enableHighlightJs }}
-    <script src="{{ "theme-moment-highlight.js" | absURL }}"></script>
-    {{ else if .Site.Params.enableMomentJs }}
-    <script src="{{ "theme-moment.js" | absURL }}"></script>
-    {{ else if .Site.Params.enableHighlightJs }}
-    <script src="{{ "theme-highlight.js" | absURL }}"></script>
+    {{- $noMoment    := not (.Site.Params.enableMomentJs    | default true) -}}
+    {{- $noHighlight := not (.Site.Params.enableHighlightJs | default true) -}}
+    {{ if and $noMoment $noHighlight }}
+    <script src="{{ "theme-noMoment-noHighlight.js" | absURL }}"></script>
+    {{ else if $noMoment }}
+    <script src="{{ "theme-noMoment.js" | absURL }}"></script>
+    {{ else if $noHighlight }}
+    <script src="{{ "theme-noHighlight.js" | absURL }}"></script>
     {{ else }}
     <script src="{{ "theme.js" | absURL }}"></script>
     {{ end }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -116,8 +116,15 @@
     {{ partial "mathjax.html" . }}
     {{ end }}
 
-
+    {{ if and .Site.Params.enableMomentJs .Site.Params.enableHighlightJs }}
+    <script src="{{ "theme-moment-highlight.js" | absURL }}"></script>
+    {{ else if .Site.Params.enableMomentJs }}
+    <script src="{{ "theme-moment.js" | absURL }}"></script>
+    {{ else if .Site.Params.enableHighlightJs }}
+    <script src="{{ "theme-highlight.js" | absURL }}"></script>
+    {{ else }}
     <script src="{{ "theme.js" | absURL }}"></script>
+    {{ end }}
 
     {{ if isset .Site.Params "js_modules" }}
     {{ range .Site.Params.js_modules }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -119,11 +119,11 @@
     {{- $noMoment    := not (.Site.Params.enableMomentJs    | default true) -}}
     {{- $noHighlight := not (.Site.Params.enableHighlightJs | default true) -}}
     {{ if and $noMoment $noHighlight }}
-    <script src="{{ "theme-no-moment-no-highlight.js" | absURL }}"></script>
+    <script src="{{ "theme-exclude-moment-and-highlight.js" | absURL }}"></script>
     {{ else if $noMoment }}
-    <script src="{{ "theme-no-moment.js" | absURL }}"></script>
+    <script src="{{ "theme-exclude-moment.js" | absURL }}"></script>
     {{ else if $noHighlight }}
-    <script src="{{ "theme-no-highlight.js" | absURL }}"></script>
+    <script src="{{ "theme-exclude-highlight.js" | absURL }}"></script>
     {{ else }}
     <script src="{{ "theme.js" | absURL }}"></script>
     {{ end }}

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -17,7 +17,12 @@ mix.autoload({
 
 mix.setPublicPath('./static')
 .setResourceRoot('./')
-.js('assets/js/theme.js', './')
+.js('assets/js/theme.js', './theme.js')
+// MomentJS and HightlighJS are quire big and thus we create variants
+// that can be used with or without them!
+.js(['assets/js/theme.js', 'assets/js/moment.js'], './theme-moment.js')
+.js(['assets/js/theme.js', 'assets/js/highlight.js'], './theme-highlight.js')
+.js(['assets/js/theme.js', 'assets/js/moment.js', 'assets/js/highlight.js'], './theme-moment-highlight.js')
 .sass('assets/sass/theme.scss', './')
 .then(() => {
   const fs = require("fs");

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -17,12 +17,12 @@ mix.autoload({
 
 mix.setPublicPath('./static')
 .setResourceRoot('./')
-.js('assets/js/theme.js', './theme.js')
 // MomentJS and HightlighJS are quire big and thus we create variants
 // that can be used with or without them!
-.js(['assets/js/theme.js', 'assets/js/moment.js'], './theme-moment.js')
-.js(['assets/js/theme.js', 'assets/js/highlight.js'], './theme-highlight.js')
-.js(['assets/js/theme.js', 'assets/js/moment.js', 'assets/js/highlight.js'], './theme-moment-highlight.js')
+.js('assets/js/theme.js', './theme-noMoment-noHighlight.js')
+.js(['assets/js/theme.js', 'assets/js/moment.js'], './theme-noHighlight.js')
+.js(['assets/js/theme.js', 'assets/js/highlight.js'], './theme-noMoment.js')
+.js(['assets/js/theme.js', 'assets/js/moment.js', 'assets/js/highlight.js'], './theme.js')
 .sass('assets/sass/theme.scss', './')
 .then(() => {
   const fs = require("fs");

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -19,9 +19,9 @@ mix.setPublicPath('./static')
 .setResourceRoot('./')
 // MomentJS and HightlighJS are quire big and thus we create variants
 // that can be used with or without them!
-.js('assets/js/theme.js', './theme-no-moment-no-highlight.js')
-.js(['assets/js/theme.js', 'assets/js/moment.js'], './theme-no-highlight.js')
-.js(['assets/js/theme.js', 'assets/js/highlight.js'], './theme-no-moment.js')
+.js('assets/js/theme.js', './theme-exclude-moment-and-highlight.js')
+.js(['assets/js/theme.js', 'assets/js/moment.js'], './theme-exclude-highlight.js')
+.js(['assets/js/theme.js', 'assets/js/highlight.js'], './theme-exclude-moment.js')
 .js(['assets/js/theme.js', 'assets/js/moment.js', 'assets/js/highlight.js'], './theme.js')
 .sass('assets/sass/theme.scss', './')
 .then(() => {

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -19,9 +19,9 @@ mix.setPublicPath('./static')
 .setResourceRoot('./')
 // MomentJS and HightlighJS are quire big and thus we create variants
 // that can be used with or without them!
-.js('assets/js/theme.js', './theme-noMoment-noHighlight.js')
-.js(['assets/js/theme.js', 'assets/js/moment.js'], './theme-noHighlight.js')
-.js(['assets/js/theme.js', 'assets/js/highlight.js'], './theme-noMoment.js')
+.js('assets/js/theme.js', './theme-no-moment-no-highlight.js')
+.js(['assets/js/theme.js', 'assets/js/moment.js'], './theme-no-highlight.js')
+.js(['assets/js/theme.js', 'assets/js/highlight.js'], './theme-no-moment.js')
 .js(['assets/js/theme.js', 'assets/js/moment.js', 'assets/js/highlight.js'], './theme.js')
 .sass('assets/sass/theme.scss', './')
 .then(() => {


### PR DESCRIPTION
Hi,

on my personal blog I don't need momentJS and also the builtin syntax highlighting of hugo is totally enough for me, thus I also don't highlightJS on my page.

This is especially annoying, as those two are quite big dependencies after all 😢 

So in this PR I've managed to create multiple variations of the `theme.js` file wether or not it contains momentJS, highlightJS, both or none of them. With those varied files at hand (all managed by laravel-mix so nothing to maintain manually btw!) we can simply decide in our `baseof.html` which one to load.

In order to keep a somewhat consistent look & feel I also picked `pastie` as the theme of the builtin syntax highlighter of hugo.

Here the results

| `enableHighlightJs` | `enableMomentJs` | output | size | size gzipped |
|----|---|--|--|--|
| ✅ | ✅ | `theme.js` | 1.6MiB | 474KiB |
| ✅ | ❌ | `theme-exclude-moment.js` | 1.09MiB | 347KiB |
| ❌ | ✅ | `theme-exclude-highlight.js` | 806KiB | 212KiB |
| ❌ | ❌ | `theme-exclude-moment-and-highlight.js` | 288KiB | 85KiB |

So, from a performance point of view, I think this is a big win for some users 😄 