### PR TITLE
Pass "." as current scope to the hook partials

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -97,11 +97,11 @@
         {{ end }}
     {{ end }}
 
-    {{ partial "hooks/head-end.html" }}
+    {{ partial "hooks/head-end.html" . }}
 </head>
 
 <body class="bilberry-hugo-theme">
-    {{ partial "hooks/body-start.html" }}
+    {{ partial "hooks/body-start.html" . }}
 
     {{ partial "topnav.html" . }}
 
@@ -132,7 +132,7 @@
     {{ partial "algolia-search.html" . }}
     {{ end }}
 
-    {{ partial "hooks/body-end.html" }}
+    {{ partial "hooks/body-end.html" . }}
 </body>
 
 </html>


### PR DESCRIPTION
In https://github.com/Lednerb/bilberry-hugo-theme/pull/489 I introduced three new hooks but I totally missed to pass on `.` as scope 😞 

This PR will fix that mistake 🤞 