### PR TITLE
Add Workflow to update static files

### DIFF
--- a/.github/workflows/update-readme-toc.yml
+++ b/.github/workflows/update-readme-toc.yml
@@ -1,12 +1,14 @@
-name: Generate README TOC
+name: Update README TOC
 
 on:
   pull_request:
-    branches: "*"
+    branches:
+      - master
+    paths:
+      - README.md
 
 jobs:
-  generateTOC:
-    name: Generate TOC
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: technote-space/toc-generator@v4

--- a/.github/workflows/update-static-files.yml
+++ b/.github/workflows/update-static-files.yml
@@ -1,0 +1,35 @@
+name: Update Static Files
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - assets/js/**
+      - assets/sass/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Clean old build artifacts
+        run: rm -rf ./static/theme*.js* ./static/theme*.css*
+
+      - name: Create build artifacts
+        run: npm run production
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "npm run production"
+          add_options: --all
+          file_pattern: ./static/


### PR DESCRIPTION
Hi,

this PR introduces a new workflow to update the static JS & CSS theme files within `./static` folder on every push to the `master` branch. I think running it on every branch would just lead to useless merge conflicts.

I also changed the README-TOC workflow to have a consequent workflow file naming pattern (`update-*` for all workflows that update / change something), and also restricted the execution to only the `master` branch in combination with actual changes to the `README.md` file.