### PR TITLE
fix: Issue with "Continue Reading" link not displayed after summary split

### DIFF
--- a/layouts/partials/default-content.html
+++ b/layouts/partials/default-content.html
@@ -55,7 +55,7 @@
     {{ else }}
         {{ .ctx.Summary }}
 
-        {{ if .ctx.Truncated }}
+        {{ if or (.ctx.Truncated) (isset .ctx.Params "summary") }}
             <a href="{{ .ctx.Permalink }}" class="more">{{ i18n "continueReading" }}</a>
         {{ end }}
     {{ end }}


### PR DESCRIPTION
**Issue** https://github.com/Lednerb/bilberry-hugo-theme/issues/499