### PR TITLE
fix(v4): mod declaration of font-family in scss

### DIFF
--- a/v4/assets/sass/_bilberry-hugo-theme.scss
+++ b/v4/assets/sass/_bilberry-hugo-theme.scss
@@ -49,7 +49,7 @@
 
             code {
                 background-color: inherit;
-                font-family: $article-footer-font;
+                font-family: $code-block-font;
                 border: 0;
                 margin: 0;
                 padding: 1.0em;
@@ -63,7 +63,7 @@
                 position: absolute;
                 top: 5px;
                 right: 5px;
-                background: #f1f1f1;
+                background: $page-background-color;
                 padding: 4px;
                 font-size: 12pt;
                 line-height: normal;

--- a/v4/assets/sass/_bilberry-hugo-theme.scss
+++ b/v4/assets/sass/_bilberry-hugo-theme.scss
@@ -49,7 +49,7 @@
 
             code {
                 background-color: inherit;
-                font-family: "Fira Code", monospace;
+                font-family: $article-footer-font;
                 border: 0;
                 margin: 0;
                 padding: 1.0em;

--- a/v4/assets/sass/theme.scss
+++ b/v4/assets/sass/theme.scss
@@ -7,6 +7,7 @@ $site-width: {{ .Param "siteWidth" | default "800px" }};
 $headline-font: {{ .Param "headlineFont" | default "'Comfortaa',sans-serif" }};
 $content-font: {{ .Param "contentFont" | default "'Open Sans',sans-serif" }};
 $article-footer-font: {{ .Param "articleFooterFont" | default "'Fira Code',monospace" }};
+$code-block-font: {{ .Param "codeBlockFont" | default "'Fira Code',monospace" }};
 
 $page-background-color: {{ .Param "pageBackgroundColor" | default "#f1f1f1" }};
 $base-color: {{ .Param "baseColor" | default "#1d1f38" }};


### PR DESCRIPTION
A font-family is declared specifically in one place, but it's better to use variables for customizability, I guess.  
All of the other font declarations seem to use variables nicely.