### PR TITLE
fix(v4): adjust margins in title container

### DIFF
--- a/v4/assets/sass/_header.scss
+++ b/v4/assets/sass/_header.scss
@@ -75,6 +75,8 @@ header {
 
     .titles {
         margin-left: 3rem;
+        margin-top: 3em;
+        margin-bottom: 3em;
 
         h3 {
             margin-bottom: 0;


### PR DESCRIPTION
A simple improvement in the appearance of the title container with a narrow window width for https://github.com/Lednerb/bilberry-hugo-theme/issues/256.  
This patch should not affect when a window has enough width.

![image](https://github.com/Lednerb/bilberry-hugo-theme/assets/68371029/dcea6985-91fd-410f-8c1d-a695de75447e)