### PR TITLE
Update render-image.html to fix dimbox in List View

### DIFF
--- a/v4/layouts/_default/_markup/render-image.html
+++ b/v4/layouts/_default/_markup/render-image.html
@@ -1,12 +1,42 @@
+{{- $u := urls.Parse .Destination -}}
+{{- $src := $u.String -}}
+{{- if not $u.IsAbs -}}
+  {{- $path := strings.TrimPrefix "./" $u.Path }}
+  {{- with or (.PageInner.Resources.Get $path) (resources.Get $path) -}}
+    {{- $src = .RelPermalink -}}
+    {{- with $u.RawQuery -}}
+      {{- $src = printf "%s?%s" $src . -}}
+    {{- end -}}
+    {{- with $u.Fragment -}}
+      {{- $src = printf "%s#%s" $src . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $attributes := merge .Attributes (dict "alt" .Text "src" $src "title" (.Title | transform.HTMLEscape)) -}}
+
+{{- /* Define the href for the anchor tag, it could be same as the image src or another variable */ -}}
+{{- $href := $src | default $src -}}
+
 {{ if .Title }}
 <figure>
-    <a href="{{ .Destination | safeURL }}" data-dimbox data-dimbox-caption="{{ .Text }}">
-        <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" />
+    <a href="{{ $href | safeURL }}" data-dimbox data-dimbox-caption="{{ .Text }}">
+      <img
+      {{- range $k, $v := $attributes -}}
+        {{- if $v -}}
+          {{- printf " %s=%q" $k $v | safeHTMLAttr -}}
+        {{- end -}}
+      {{- end -}} />
     </a>
     <figcaption>{{ .Title }}</figcaption>
 </figure>
 {{ else }}
-<a href="{{ .Destination | safeURL }}" data-dimbox data-dimbox-caption="{{ .Text }}">
-    <img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" />
+<a href="{{ $href | safeURL }}" data-dimbox data-dimbox-caption="{{ .Text }}">
+  <img
+    {{- range $k, $v := $attributes -}}
+      {{- if $v -}}
+        {{- printf " %s=%q" $k $v | safeHTMLAttr -}}
+      {{- end -}}
+    {{- end -}} />
 </a>
 {{ end }}
+{{- /**/ -}}


### PR DESCRIPTION
Fix for [#635](https://github.com/Lednerb/bilberry-hugo-theme/issues/635)

Updated the render-image render hook based on the [official HUGO embedded render image hook](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html) so it works in the List View when noSummary is enabled in the post's front matter. It could be simpler but I tried to keep it as close to the official HUGO embedded Image render hook and the current theme's Dimbox implementation. 

From what I saw, HUGO updated the included Image render hook to resolve this type of situations not long (some weeks?) ago.

It's currently working on my end but some further testing is advised.

References
- [HUGO Image Render Hook Code](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/_markup/render-image.html)
- [HUGO Image Render Hook Docs](https://gohugo.io/render-hooks/images/#default)
