### PR TITLE
docs: fix links to v4

### DIFF
--- a/v4/README.md
+++ b/v4/README.md
@@ -13,9 +13,9 @@
 This guide is for the `v4` version. For `v3`, please use this [guide](../v3-README.md).
 
 **IMPORTANT** `v3` will be supported until **August 31, 2024**. Only critical bugs will be fixed during this period, and no
-new features will be implemented. If you want to migrate from `v3` to `v4`, please read the migration [guide](v4-migration-guide.md).
+new features will be implemented. If you want to migrate from `v3` to `v4`, please read the migration [guide](../v4/v4-migration-guide.md).
 
-For those who want to contribute to or customize the Bilberry Hugo theme, please see the developer [guide](v4-developer-guide.md).
+For those who want to contribute to or customize the Bilberry Hugo theme, please see the developer [guide](../v4/v4-developer-guide.md).
 
 ----
 


### PR DESCRIPTION
As home [readme](https://github.com/Lednerb/bilberry-hugo-theme?tab=readme-ov-file) is a symlink to the readme of the v4, some links are broken.


---

https://github.com/Lednerb/bilberry-hugo-theme/blob/master/.github/v4-migration-guide.md
instead of
https://github.com/Lednerb/bilberry-hugo-theme/blob/master/v4/v4-migration-guide.md

---

https://github.com/Lednerb/bilberry-hugo-theme/blob/master/.github/v4-developer-guide.md
instead of
https://github.com/Lednerb/bilberry-hugo-theme/blob/master/v4/v4-developer-guide.md
