### PR TITLE
feat: add content-font-size variable

### DIFF
--- a/v4/assets/sass/_bilberry-hugo-theme.scss
+++ b/v4/assets/sass/_bilberry-hugo-theme.scss
@@ -8,7 +8,7 @@
     background-color: $page-background-color;
     font-family: $content-font;
     color: $text-color;
-    font-size: 1.6em;
+    font-size: $content-font-size;
 
     h1,
     h2,

--- a/v4/assets/sass/theme.scss
+++ b/v4/assets/sass/theme.scss
@@ -6,6 +6,7 @@ $site-width: {{ .Param "siteWidth" | default "800px" }};
 
 $headline-font: {{ .Param "headlineFont" | default "'Comfortaa',sans-serif" }};
 $content-font: {{ .Param "contentFont" | default "'Open Sans',sans-serif" }};
+$content-font-size: {{ .Param "contentFontSize" | default "1.6em" }};
 $article-footer-font: {{ .Param "articleFooterFont" | default "'Fira Code',monospace" }};
 $code-block-font: {{ .Param "codeBlockFont" | default "'Fira Code',monospace" }};
 


### PR DESCRIPTION
This adds the ability to adjust font size through a hugo.toml variable contentFontSize.

The default remains 1.6em.