### PR TITLE
fix: multilanguage links for different domains

### DIFF
--- a/v4/layouts/partials/footer.html
+++ b/v4/layouts/partials/footer.html
@@ -50,9 +50,9 @@
                 <div class="languages">
                     <strong>{{ i18n "otherLanguages" }}</strong>
                     {{ range $.Site.Home.AllTranslations }}
-                        {{ $url := .RelPermalink }}
+                        {{ $url := .Permalink }}
                         {{ range where $pages "Lang" .Language.Lang }}
-                            {{ $url = .RelPermalink }}
+                            {{ $url = .Permalink }}
                         {{ end }}
 
                         {{ if eq $language .Language }}

--- a/v4/layouts/partials/header.html
+++ b/v4/layouts/partials/header.html
@@ -47,9 +47,9 @@
             {{- $pages := .Page.AllTranslations -}}
             <div class="languages">
             {{ range $.Site.Home.AllTranslations }}
-                {{ $url := .RelPermalink }}
+                {{ $url := .Permalink }}
                 {{ range where $pages "Lang" .Language.Lang }}
-                  {{ $url = .RelPermalink }}
+                  {{ $url = .Permalink }}
                 {{ end }}
 
                 {{ if eq $language .Language }}


### PR DESCRIPTION
Since v4 i had a small problem on my website that was hosted on different domains (or subdomain) for each language, instead of a directory: the language switchers on header and footer were displaying the right URL but wrong domain (discussion #626 )

I said "I will investigate this in the next days" but i completely forgot about it and only remembered it a full year after that 😂

I compared the part of the template that was working correctly (article-footer.html) and it looks like it was because on header.html and footer.html it was using relative urls instead of absolute, so the domain would not change.

I tested this small change on my website and it works good

Didn't test for a configuration where the language is on a subdirectory instead of a subdomain